### PR TITLE
CP-725 ViewModule should be available as a Module and a Mixin

### DIFF
--- a/lib/src/view_module.dart
+++ b/lib/src/view_module.dart
@@ -2,9 +2,11 @@ library w_module.src.view_module;
 
 import 'module.dart';
 
-abstract class ViewModule extends Module {
+abstract class ViewModuleMixin {
   buildComponent();
 }
+
+abstract class ViewModule extends Module with ViewModuleMixin {}
 
 abstract class ViewModuleWithToolbar extends ViewModule {
   buildToolbarComponent();


### PR DESCRIPTION
## Issue

This allows consumers creating ViewModules to continue to inherit directly from `ViewModule` while allowing consumers with a deeper inheritance tree to add the abstract methods that `ViewModule` provides with a `ViewModuleMixin`

Specifically this accounts for the case where the `BasicShell` in truss extends `Module` and eventually `SessionUiShell` extends `BasicShell` but also needs to be a `ViewModule`... with this change we can do:

``` dart
class SessionUiShell extends BasicShell with ViewModuleMixin
```
## Changes

**Source:**
- Add `ViewModuleMixin`
- `ViewModule` now uses `ViewModuleMixin`

**Tests:**
- No tests for abstract classes.
## Areas of Regression
- None
## Testing
- CI passes

@trentgrover-wf 
@evanweible-wf 
FYI @jayudey-wf
