### PR TITLE
RECON-1500 Add DataProvider to w_module

### DIFF
--- a/lib/src/data_provider.dart
+++ b/lib/src/data_provider.dart
@@ -1,0 +1,11 @@
+library w_module.src.data_provider;
+
+abstract class DataProvider<ApiT, EventsT> {
+  ApiT _api;
+  ApiT get api => _api;
+
+  EventsT _events;
+  EventsT get events => _events;
+
+  DataProvider(this._api, this._events);
+}

--- a/lib/w_module.dart
+++ b/lib/w_module.dart
@@ -1,5 +1,6 @@
 library w_module;
 
+export 'src/data_provider.dart';
 export 'src/event.dart';
 export 'src/lifecycle_module.dart';
 export 'src/module.dart';


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/RECON-1500

### FEATURE
Adding a DataProvider class to w_module which modules may use in describing data they expect or can have passed to them by an external context.

Module would define a concrete API and Event object documenting to the user any external requirements the module may have. Consumers of the Module need only implement an Adapter which provides fulfillment of the required api and events.

### IMPLEMENTATION DETAILS
Module would declare a DataProvider signature like so.
```dart
abstract class ColorPickerDPAPI {
  List<Color> get colors;
}

abstract class ColorPickerDPEvents {
  Event<List<Color>> get colorsChanged;
}

class ColorPickerModule extends Module {
  DataProvider<ColorPickerDPAPI, ColorPickerDPEvents> _dataProvider;
  ColorPickerModule([this._dataProvider]) {
    if (_dataProvider == null) _dataProvider = new DefaultDP();
  }

  // This module, its store, and its components can now hook themselves up to external colors state.
}
```
Now, any application that want's to use the ColorPickerModule need only implement an Adapter that fulfills the DataProvider signature to use the module with confidence.
```dart
class MyColorPickerAdapter extends DataProvider<ColorPickerDPAPI, ColorPickerDPEvents> {
  MyColorPickerAdapter(ColorStore source) : super(new MyColorPickerAPI(source), new MyColorPickerEvents(source));
}

MyAPI implements ColorPickerDPAPI {
  ColorStore _source; // could also be a Module or other dart object maintaining state
  MyAPI(this._source)

  List<Color> get colors => new List<Color>.from(_source.getColors().map((c) => new Color.fromString(c)));
}

MyEvents implements ColorPickerDPEvents {
  ColorStore _source;
  MyEvents(this._source)

  // demo code, onColorsChanged probably returns List<String>
  Event<List<Color>> get colorsChanged => _source.onColorsChanged;
}
```

So now using ColorPickerModule is a simple matter of creating it and feeding it its provider.
```dart
onLoad() {
  _colorStore = new ColorStore();
  _modules.colorPicker = new ColorPickerModule(new MyColorPickerAdapter(_colorStore));
}
```

Note that there is no wiring ColorPickerModule up to ColorStore in this parent module. No need to maintain Colors state inside the color picker, or expose api and events meant only for synchronizing that internal copy of state. ColorStore and ColorPickerModule need not know anything about one another, they can exist in completely separate repos without any importing of one another. Consumers of ColorPickerModule don't need to know anything about the internal's or lifecycle of ColorPickerModule to use it or hook it up. Failing to meet the DataProvider signature produces a build error explaining exactly what is needed by ColorPickerModule that isn't being provided.