### PR TITLE
CP-1031 fix page load reject in panel example

### DIFF
--- a/example/panel/panel_app.dart
+++ b/example/panel/panel_app.dart
@@ -15,7 +15,9 @@
 library w_module.example.panel;
 
 import 'dart:html';
+import 'dart:js' as js;
 
+import 'package:browser_detect/browser_detect.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart' as react_client;
 import 'package:w_module/w_module.dart';
@@ -31,12 +33,17 @@ main() async {
   await panelModule.load();
 
   // block browser tab / window close if necessary
-  window.onBeforeUnload.listen((event) {
+  window.onBeforeUnload.listen((BeforeUnloadEvent event) {
     // can the app be unloaded?
     ShouldUnloadResult res = panelModule.shouldUnload();
     if (!res.shouldUnload) {
       // return the supplied error message to block close
-      return res.messagesAsString();
+      event.returnValue = res.messagesAsString();
+    } else if (browser.isIe) {
+      // IE interprets a null string as a response and displays an alert to
+      // the user. Use the `undefined` value of the JS context instead.
+      // https://github.com/dart-lang/sdk/issues/22589
+      event.returnValue = js.context['undefined'];
     }
   });
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: w_module
 version: 0.3.0
 dev_dependencies:
   browser: "^0.10.0+2"
+  browser_detect: "^1.0.3"
   coverage: "^0.7.2"
   dart_dev: "^1.0.0"
   dart_style: "^0.2.0"


### PR DESCRIPTION
## Issue
- fix https://github.com/Workiva/w_module/issues/28
- in panel example, rejecting unload via closing a browser tab / window fails in non-dartium browsers (closes without prompting user for confirmation)
## Changes

**Source:**
- proper window.onBeforeUnload event handling added to panel example

**Tests:**
- none, example changes only
## Areas of Regression
- none
## Testing
- ensure that panel example unload can be rejected in non-dartium browsers
## Code Review

@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf 
@jayudey-wf
