### PR TITLE
CP-1174 Add Child Modules Getter to LifecycleModule

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -24,6 +24,7 @@ abstract class LifecycleModule {
 
   /// List of child components so that lifecycle can iterate over them as needed
   List<LifecycleModule> _childModules = [];
+  Iterable<LifecycleModule> get childModules => _childModules;
 
   // Broadcast streams for the module's lifecycle events.
 

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -127,6 +127,17 @@ void main() {
       expect(childModule.eventList, equals(['willLoad', 'onLoad', 'didLoad']));
     });
 
+    test('childModules returns an iterable of loaded child modules', () async {
+      var childModuleB = new TestLifecycleModule();
+      await parentModule.loadChildModule(childModule);
+      await parentModule.loadChildModule(childModuleB);
+      await new Future(() {});
+      expect(parentModule.childModules,
+          new isInstanceOf<Iterable<LifecycleModule>>());
+      expect(parentModule.childModules.toList(),
+          equals([childModule, childModuleB]));
+    });
+
     test('should unload child modules when parent in unloaded', () async {
       await parentModule.loadChildModule(childModule);
       parentModule.eventList = [];


### PR DESCRIPTION
## Problem:
It would be helpful to have a getter to access the `_childModules` list that is maintained by the `LifecycleModule`. Specifically, as someone who is extending the `LifecycleModule` it would be nice to not have to maintain my own list of child modules when it's already being managed by the parent class.

## Solution:
Added a getter that exposes the `_childModules` list as an `Iterable<LifecycleModule>`.

## Possible Areas of Regression:
None -- this is just the introduction of a getter property for an existing field.