### PR TITLE
CP-1335 Add DeferredModule transformer, w_module.

### DIFF
--- a/example/deferred/counter_module.dart
+++ b/example/deferred/counter_module.dart
@@ -1,0 +1,132 @@
+library w_module.example.deferred_transformer.counter_module;
+
+import 'dart:async';
+
+import 'package:react/react.dart' as react;
+import 'package:w_module/alpha/annotations.dart';
+import 'package:w_module/w_module.dart';
+
+import 'counter_module_abstracts.dart';
+import 'pair.dart';
+
+DispatchKey _dispatchKey = new DispatchKey('counterModule');
+
+@DeferrableModule('CounterModule')
+class CounterModule extends Module implements CounterModuleDef {
+  CounterApi _api;
+  CounterComponents _components;
+  CounterEvents _events;
+
+  CounterModule({int startingCount}) : this._(startingCount: startingCount);
+
+  CounterModule.autoIncrement({int startingCount})
+      : this._(autoIncrement: true, startingCount: startingCount);
+
+  CounterModule._({bool autoIncrement, int startingCount}) {
+    _events = new CounterEvents();
+    _api = new CounterApi(_events,
+        autoIncrement: autoIncrement ?? false, count: startingCount ?? 0);
+    _components = new CounterComponents(_api, events);
+  }
+
+  @override
+  String get name => 'DeferredCounterModule';
+
+  @override
+  CounterApi get api => _api;
+
+  @override
+  CounterComponents get components => _components;
+
+  @override
+  CounterEvents get events => _events;
+}
+
+@DeferrableModuleApi('CounterModule')
+class CounterApi implements CounterApiDef {
+  bool _autoIncrement;
+  int _count = 0;
+  CounterEvents _events;
+
+  CounterApi(CounterEvents events, {bool autoIncrement: false, int count})
+      : _autoIncrement = autoIncrement,
+        _count = count,
+        _events = events;
+
+  bool get autoIncrement => _autoIncrement;
+  int get count => _count;
+  List<Pair<DateTime, int>> get history => [];
+
+  Future<Null> increment({int delta}) async {
+    _updateCount(_count + (delta ?? 1));
+  }
+
+  Future<Null> decrement({int delta}) async {
+    _updateCount(_count - (delta ?? 1));
+  }
+
+  Future<Null> update(int count) async {
+    _updateCount(count);
+  }
+
+  doNothing() {}
+
+  void _updateCount(int count) {
+    _count = count;
+    _events.onCountChange(count, _dispatchKey);
+  }
+}
+
+class CounterComponents implements CounterComponentsDef, ModuleComponents {
+  CounterApi _api;
+  CounterEvents _events;
+  CounterComponents(this._api, this._events);
+  content() => CounterComponent({'api': _api, 'events': _events});
+}
+
+@DeferrableModuleEvents('CounterModule')
+class CounterEvents implements CounterEventsDef {
+  final Event<int> onCountChange = new Event(_dispatchKey);
+}
+
+var CounterComponent = react.registerComponent(() => new _CounterComponent());
+
+class _CounterComponent extends react.Component {
+  CounterApi get api => props['api'];
+  CounterEvents get events => props['events'];
+
+  StreamSubscription countChangeSub;
+  Timer autoIncrementTimer;
+
+  componentDidMount(rootNode) {
+    countChangeSub = events.onCountChange.listen((_) {
+      redraw();
+    });
+
+    if (api.autoIncrement) {
+      autoIncrementTimer = new Timer.periodic(new Duration(seconds: 1), (_) {
+        api.increment();
+      });
+    }
+  }
+
+  componentWillUnmount() {
+    autoIncrementTimer?.cancel();
+    countChangeSub?.cancel();
+  }
+
+  render() {
+    var incButton = react.button({'onClick': _inc}, '+');
+    var decButton = react.button({'onClick': _dec}, '-');
+    return react.div(
+        {}, [react.div({}, 'Counter: ${api.count}'), incButton, decButton]);
+  }
+
+  _inc(e) {
+    api.increment();
+  }
+
+  _dec(e) {
+    api.decrement();
+  }
+}

--- a/example/deferred/counter_module_abstracts.dart
+++ b/example/deferred/counter_module_abstracts.dart
@@ -1,0 +1,38 @@
+library w_module.example.deferred_transformer.counter_module_abstracts;
+
+import 'dart:async';
+
+import 'package:w_module/w_module.dart';
+
+import 'pair.dart';
+
+abstract class CounterModuleDef implements Module {
+  CounterModuleDef({int startingCount});
+  CounterModuleDef.autoIncrement({int startingCount});
+
+  @override
+  CounterApiDef get api;
+
+  @override
+  CounterComponentsDef get components;
+
+  @override
+  CounterEventsDef get events;
+}
+
+abstract class CounterApiDef {
+  int get count;
+  List<Pair<DateTime, int>> get history => [];
+
+  Future<Null> increment({int delta});
+
+  Future<Null> decrement({int delta});
+
+  Future<Null> update(int count);
+}
+
+abstract class CounterComponentsDef extends ModuleComponents {}
+
+abstract class CounterEventsDef {
+  Event<int> get onCountChange;
+}

--- a/example/deferred/deferred_counter_module.dart
+++ b/example/deferred/deferred_counter_module.dart
@@ -1,0 +1,34 @@
+library w_module.example.deferred_transformer.deferred_counter_module;
+
+import 'package:react/react.dart' as react;
+import 'package:w_module/alpha/annotations.dart';
+import 'package:w_module/w_module.dart';
+
+import 'counter_module_abstracts.dart';
+import 'counter_module.dart' deferred as counter_module;
+
+@DeferredModule('CounterModule', 'counter_module')
+class DeferredCounterModule extends Module implements CounterModuleDef {
+  static get loadingComponent => react.div({}, 'Loading...');
+
+  @override
+  String get name => 'DeferredCounterModule';
+
+  @override
+  CounterApiDef get api;
+
+  @override
+  CounterComponentsDef get components;
+
+  @override
+  CounterEventsDef get events;
+
+  // TODO: use this instead of string arg to DeferredModule annotation
+  get deferredLibrary => counter_module.loadLibrary;
+
+  // Construct a standard counter module.
+  DeferredCounterModule({int startingCount: 0});
+
+  // Construct a counter module that auto increments by 1 every second.
+  DeferredCounterModule.autoIncrement({int startingCount: 0});
+}

--- a/example/deferred/index.dart
+++ b/example/deferred/index.dart
@@ -1,0 +1,35 @@
+library w_module.example.deferred_transformer.index;
+
+import 'dart:async';
+import 'dart:html';
+
+import 'package:react/react.dart' as react;
+import 'package:react/react_client.dart';
+
+import 'deferred_counter_module.dart';
+
+Element container = querySelector('#container');
+ButtonElement load = querySelector('#load');
+ButtonElement loadAlt = querySelector('#load-alt');
+
+void main() {
+  setClientConfiguration();
+
+  load.onClick.listen((_) {
+    loadAndRender(new DeferredCounterModule());
+  });
+
+  loadAlt.onClick.listen((_) {
+    loadAndRender(new DeferredCounterModule.autoIncrement());
+  });
+}
+
+Future loadAndRender(DeferredCounterModule counterModule) async {
+  react.render(DeferredCounterModule.loadingComponent, container);
+
+  counterModule.events.onCountChange.listen((c) => print('Count: $c'));
+  counterModule.api.update(10);
+
+  await counterModule.load();
+  react.render(counterModule.components.content(), container);
+}

--- a/example/deferred/index.html
+++ b/example/deferred/index.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+    <script src="packages/react/react.js"></script>
+    <script src="index.dart" type="application/dart"></script>
+</head>
+<body>
+    <div id="container">
+        <button id="load">Load Deferred Counter</button>
+        <button id="load-alt">Load Deferred Counter (auto increment)</button>
+    </div>
+</body>
+</html>

--- a/example/deferred/index.html
+++ b/example/deferred/index.html
@@ -2,6 +2,7 @@
 <head>
     <script src="packages/react/react.js"></script>
     <script src="index.dart" type="application/dart"></script>
+    <script src="packages/browser/dart.js"></script>
 </head>
 <body>
     <div id="container">

--- a/example/deferred/pair.dart
+++ b/example/deferred/pair.dart
@@ -1,0 +1,7 @@
+library w_module.example.deferred_transformer.pair;
+
+class Pair<F, S> {
+  F first;
+  S second;
+  Pair(this.first, this.second);
+}

--- a/example/index.html
+++ b/example/index.html
@@ -26,6 +26,7 @@ limitations under the License.
             <ul>
                 <li><a href="random_color/">Random Color Generator</a></li>
                 <li><a href="panel/">Multiple Module Panel</a></li>
+                <li><a href="deferred/">Deferred Module</a></li>
             </ul>
         </div>
     </body>

--- a/lib/alpha.dart
+++ b/lib/alpha.dart
@@ -1,7 +1,7 @@
 /// A library of classes meant only for consumption as alpha code. APIs are
 /// subject to change and may contain bugs.
 ///
-/// Currently this includes the annotations needed to utilizing the deferred
+/// Currently this includes the annotations needed to utilize the deferred
 /// module transformer (located at w_module/alpha/deferred_module_transformer).
 library w_module.alpha;
 

--- a/lib/alpha.dart
+++ b/lib/alpha.dart
@@ -1,0 +1,8 @@
+/// A library of classes meant only for consumption as alpha code. APIs are
+/// subject to change and may contain bugs.
+///
+/// Currently this includes the annotations needed to utilizing the deferred
+/// module transformer (located at w_module/alpha/deferred_module_transformer).
+library w_module.alpha;
+
+export 'package:w_module/alpha/annotations.dart';

--- a/lib/alpha/annotations.dart
+++ b/lib/alpha/annotations.dart
@@ -1,0 +1,6 @@
+library w_module.alpha.annotations;
+
+export 'package:w_module/alpha/annotations/deferrable_module.dart';
+export 'package:w_module/alpha/annotations/deferrable_module_api.dart';
+export 'package:w_module/alpha/annotations/deferrable_module_events.dart';
+export 'package:w_module/alpha/annotations/deferred_module.dart';

--- a/lib/alpha/annotations/deferrable_module.dart
+++ b/lib/alpha/annotations/deferrable_module.dart
@@ -1,0 +1,6 @@
+library w_module.alpha.annotations.module;
+
+class DeferrableModule {
+  final dynamic name;
+  const DeferrableModule(this.name);
+}

--- a/lib/alpha/annotations/deferrable_module_api.dart
+++ b/lib/alpha/annotations/deferrable_module_api.dart
@@ -1,0 +1,6 @@
+library w_module.alpha.annotations.deferrable_module_api;
+
+class DeferrableModuleApi {
+  final dynamic moduleName;
+  const DeferrableModuleApi(this.moduleName);
+}

--- a/lib/alpha/annotations/deferrable_module_events.dart
+++ b/lib/alpha/annotations/deferrable_module_events.dart
@@ -1,0 +1,6 @@
+library w_module.alpha.annotations.deferrable_module_events;
+
+class DeferrableModuleEvents {
+  final dynamic moduleName;
+  const DeferrableModuleEvents(this.moduleName);
+}

--- a/lib/alpha/annotations/deferred_module.dart
+++ b/lib/alpha/annotations/deferred_module.dart
@@ -1,0 +1,7 @@
+library w_module.alpha.annotations.deferred_module;
+
+class DeferredModule {
+  final dynamic deferredImport;
+  final dynamic moduleName;
+  const DeferredModule(this.moduleName, this.deferredImport);
+}

--- a/lib/alpha/deferred_module_transformer.dart
+++ b/lib/alpha/deferred_module_transformer.dart
@@ -1,0 +1,630 @@
+library w_module.alpha.deferred_module_transformer;
+
+import 'dart:async';
+import 'dart:mirrors' as mirrors;
+
+import 'package:analyzer/analyzer.dart';
+import 'package:barback/barback.dart';
+import 'package:source_span/source_span.dart';
+import 'package:transformer_utils/transformer_utils.dart';
+
+import 'package:w_module/alpha/annotations.dart' as annotations;
+
+String _getReflectedName(Type type) =>
+    mirrors.MirrorSystem.getName(mirrors.reflectType(type).simpleName);
+
+/// Aggregate transformer that generates the implementation logic for a deferred
+/// module. The generated implementation takes care of the following:
+///
+/// - Loading the deferred library that contains the real module class when the
+///   deferred module's "onLoad" event occurs.
+/// - Deferring the availability of API, Components, and Events on the deferred
+///   module until the underlying module has actually been loaded. In other
+///   words, attempting to access the API, Components, or Events will throw if
+///   the module hasn't been loaded. Once loaded, these calls will be proxied to
+///   the real, underlying module.
+/// - Proxying of constructors. Any constructor defined in the deferred module
+///   class that matches a constructor defined in the real module will have
+///   bodies generated that store the given arguments and proxy them to the
+///   constructors on the real module when it is constructed.
+class DeferredModuleTransformer extends AggregateTransformer {
+  final BarbackSettings _settings;
+
+  DeferredModuleTransformer.asPlugin(this._settings);
+
+  @override
+  classifyPrimary(AssetId id) {
+    if (!id.path.endsWith('.dart')) return null;
+    return 'w_module_deferred_transformer';
+  }
+
+  @override
+  apply(AggregateTransform transform) async {
+    var deferredModuleTransformer =
+        new _DeferredModuleTransformer(_settings, transform);
+    await deferredModuleTransformer.done;
+  }
+}
+
+/// Helper class for applying the deferred module transforms to a single
+/// [AggregateTransform] instance. In other words, an instance of this class
+/// will be constructed and used each time `WModuleTransformer.apply()` is
+/// called.
+class _DeferredModuleTransformer {
+  /// A pattern that will match any usage of at least one of the following
+  /// annotations:
+  ///
+  ///   * [annotations.DeferrableModule]
+  ///   * [annotations.DeferrableModuleApi]
+  ///   * [annotations.DeferrableModuleEvents]
+  ///   * [annotations.DeferredModule]
+  static final RegExp _anyDeferredModuleAnnotation = new RegExp(
+      r'@(' +
+          [
+            _getReflectedName(annotations.DeferrableModule),
+            _getReflectedName(annotations.DeferrableModuleApi),
+            _getReflectedName(annotations.DeferrableModuleEvents),
+            _getReflectedName(annotations.DeferredModule),
+          ].join('|') +
+          r')',
+      caseSensitive: true);
+
+  /// A naive check to determine if an asset's contents might include
+  /// annotations relevant to this deferred module transformer.
+  ///
+  /// This is a naive check because although it will always find legitimate
+  /// usages, it may also find false positives (commented out annotation or
+  /// the annotation name referenced in documentation, for example).
+  static bool _mightContainModuleAnnotations(String contents) =>
+      _anyDeferredModuleAnnotation.hasMatch(contents);
+
+  /// Future that resolves when the group of primary inputs from [transform] are
+  /// done being analyzed and transformed.
+  Future<Null> get done => _done.future;
+  Completer _done = new Completer();
+
+  /// Configuration details for the w_module pub transformer.
+  final BarbackSettings settings;
+
+  /// The aggregate transform object that provides access to a group of primary
+  /// inputs to analyze and potentially transform.
+  final AggregateTransform transform;
+
+  List<String> _deferrableModuleNames = [];
+  Map<String, NodeWithMeta<ClassDeclaration, annotations.DeferrableModuleApi>>
+      _deferrableModuleApiDeclarations = {};
+  Map<String,
+          NodeWithMeta<ClassDeclaration, annotations.DeferrableModuleEvents>>
+      _deferrableModuleEventsDeclarations = {};
+  Map<String, NodeWithMeta<ClassDeclaration, annotations.DeferredModule>>
+      _deferredModuleDeclarations = {};
+
+  /// Map of source files keyed by the asset's ID.
+  Map<AssetId, SourceFile> _sourceFiles = {};
+
+  /// Map of transformed source files keyed by the asset's ID. For every element
+  /// in this map, there will be a corresponding source file in [_sourceFiles].
+  Map<AssetId, TransformedSourceFile> _transformedSourceFiles = {};
+
+  _DeferredModuleTransformer(
+      BarbackSettings this.settings, AggregateTransform this.transform) {
+    _done.complete(_apply());
+  }
+
+  _apply() async {
+    // Iterate over all of the inputs from the [WModuleTransformer], which
+    // should be every .dart file.
+    await for (Asset asset in transform.primaryInputs) {
+      // Read the file as a string and do a naive check to see if it might
+      // contain deferred module annotations.
+      String assetContents = await asset.readAsString();
+      if (_mightContainModuleAnnotations(assetContents)) {
+        // Store the source file so that locations or spans from it can be used
+        // to make replacements or insertions.
+        Uri uri = assetIdToPackageUri(asset.id);
+        _sourceFiles[asset.id] = new SourceFile(assetContents, url: uri);
+
+        // Parse this file as a compilation unit so that the AST can be used to
+        // get the information needed to apply the deferred module transform.
+        CompilationUnit unit = parseCompilationUnit(assetContents,
+            suppressErrors: true,
+            name: asset.id.path,
+            parseFunctionBodies: false);
+
+        // Iterate over the unit looking for declarations annotated with one of
+        // the deferred module annotations.
+        _deferrableModuleNames.addAll(
+            getDeclarationsAnnotatedBy(unit, annotations.DeferrableModule)
+                .map((member) => instantiateAnnotation(member, annotations.DeferrableModule))
+                .map((annotation) => annotation.name));
+        _deferrableModuleApiDeclarations.addAll(new Map.fromIterable(
+            getDeclarationsAnnotatedBy(unit, annotations.DeferrableModuleApi)
+                .map((member) => new NodeWithMeta<ClassDeclaration, annotations.DeferrableModuleApi>(member, assetId: asset.id)),
+            key: (d) => d.meta.moduleName));
+        _deferrableModuleEventsDeclarations.addAll(new Map.fromIterable(
+            getDeclarationsAnnotatedBy(unit, annotations.DeferrableModuleEvents)
+                .map((member) => new NodeWithMeta<ClassDeclaration, annotations.DeferrableModuleEvents>(member, assetId: asset.id)),
+            key: (d) => d.meta.moduleName));
+        _deferredModuleDeclarations.addAll(new Map.fromIterable(
+            getDeclarationsAnnotatedBy(unit, annotations.DeferredModule)
+                .map((member) => new NodeWithMeta<ClassDeclaration, annotations.DeferredModule>(member, assetId: asset.id)),
+            key: (d) => d.meta.moduleName));
+      }
+    }
+
+    // Validate that every module marked as "deferrable" is setup correctly and
+    // all required annotations are present.
+    _validate();
+
+    // Attempt to transform each deferred module.
+    _deferredModuleDeclarations.forEach((moduleName, declaration) {
+      var api = _deferrableModuleApiDeclarations[moduleName];
+      var events = _deferrableModuleEventsDeclarations[moduleName];
+      _transform(moduleName, declaration, api: api, events: events);
+    });
+  }
+
+  /// It's possible that multiple deferred modules may live in the same file,
+  /// so we keep a cache of TransformedSourceFile helpers to ensure that
+  /// changes to a source file are kept in one place.
+  ///
+  /// This assumes that the [SourceFile] for [assetId] is available in
+  /// [_sourceFiles].
+  TransformedSourceFile _getTransformedSourceFile(AssetId assetId) {
+    if (!_transformedSourceFiles.containsKey(assetId)) {
+      var sourceFile = _sourceFiles[assetId];
+      _transformedSourceFiles[assetId] = new TransformedSourceFile(sourceFile);
+    }
+    return _transformedSourceFiles[assetId];
+  }
+
+  void _transform(
+      String moduleName,
+      NodeWithMeta<ClassDeclaration,
+          annotations.DeferredModule> deferredModuleDeclaration,
+      {NodeWithMeta<ClassDeclaration, annotations.DeferrableModuleApi> api,
+      NodeWithMeta<ClassDeclaration,
+          annotations.DeferrableModuleEvents> events}) {
+    // Names of the module-related classes that already exist.
+    var deferredModuleClassName = deferredModuleDeclaration.node.name.name;
+
+    // Name of the deferred import in which the real module lives.
+    var deferredLibrary = deferredModuleDeclaration.meta.deferredImport;
+
+    // Deferred module class declaration.
+    var deferredModuleNode = deferredModuleDeclaration.node;
+
+    // Names for the API, Events, and Mixin classes that will be generated.
+    var deferredModuleMixinClassName = '__$deferredModuleClassName' + 'Mixin';
+    var deferredApiClassName = '__$deferredModuleClassName' + 'Api';
+    var deferredEventsClassName = '__$deferredModuleClassName' + 'Events';
+
+    // General pieces of info about the module setup.
+    // TODO: Verify that these getters don't have implementations and are only stubs
+    var apiGetter = deferredModuleNode.members.firstWhere(
+        (m) => m is MethodDeclaration && m.name.name == 'api',
+        orElse: null);
+    var componentsGetter = deferredModuleNode.members.firstWhere(
+        (m) => m is MethodDeclaration && m.name.name == 'components',
+        orElse: null);
+    var eventsGetter = deferredModuleNode.members.firstWhere(
+        (m) => m is MethodDeclaration && m.name.name == 'events',
+        orElse: null);
+    var hasApi = apiGetter != null;
+    var hasComponents = componentsGetter != null;
+    var hasEvents = eventsGetter != null;
+
+    // File helpers.
+    var assetId = deferredModuleDeclaration.assetId;
+    var sf = _sourceFiles[assetId];
+    var tf = _getTransformedSourceFile(assetId);
+
+    // Default constructor (unnamed).
+    ConstructorDeclaration defaultCtor = deferredModuleNode.members
+        .firstWhere((m) => m is ConstructorDeclaration && m.name == null);
+    // Named constructors.
+    Iterable<ConstructorDeclaration> namedCtors = deferredModuleNode.members
+        .where((m) => m is ConstructorDeclaration && m.name != null);
+
+    // Insert a "GENERATED" banner at the bottom of the file before the
+    // generated classes are inserted.
+    var generatedBannerBuffer = new StringBuffer()
+      ..writeln()
+      ..writeln('// ====================')
+      ..writeln('// GENERATED CODE BELOW')
+      ..writeln('// ====================')
+      ..writeln();
+    tf.insert(sf.location(sf.length), generatedBannerBuffer.toString());
+
+    // STEP 1:
+    // -------
+    // Add dart:async import if necessary.
+
+    var unit = deferredModuleNode.parent;
+    Iterable<ImportDirective> imports =
+        unit.childEntities.where((e) => e is ImportDirective);
+    if (imports.where((i) => i.uriContent == 'dart:async').length == 0) {
+      tf.insert(sf.location(imports.first.beginToken.offset),
+          '/* GENERATED */ import \'dart:async\'; /* END GENERATED */');
+    }
+
+    // STEP 2:
+    // -------
+    // Generate a deferred proxy for the API class.
+
+    if (hasApi) {
+      var apiBuffer = new StringBuffer()..writeln();
+      var apiTypeName = apiGetter.returnType.name.name;
+
+      var apiDecl = _deferrableModuleApiDeclarations[moduleName];
+      if (apiDecl == null) {
+        transform.logger.error(
+            'The $moduleName module has an Api class but it could not be '
+            'found - make sure it is annotated with '
+            '@DeferrableModuleApi(\'$moduleName\').');
+      } else {
+        apiBuffer
+          ..writeln('class $deferredApiClassName implements $apiTypeName {')
+          ..writeln('  $deferredModuleClassName _deferredModule;')
+          ..writeln('  Future<$moduleName> _loaded;')
+          ..writeln(
+              '  $deferredApiClassName(this._loaded, this._deferredModule);');
+
+        var methods = apiDecl.node.members.where((m) => m is MethodDeclaration);
+        methods.forEach((member) {
+          if (member is MethodDeclaration) {
+            var name = member.name.name;
+            if (name.startsWith('_')) return;
+
+            bool isAsync = member.returnType?.name?.name == 'Future';
+            var proxy;
+            if (isAsync) {
+              var argList = [];
+              if (member.parameters != null) {
+                member.parameters.parameters.forEach((p) {
+                  if (p.kind == ParameterKind.NAMED) {
+                    argList.add('${p.identifier.name}: ${p.identifier.name}');
+                  } else {
+                    argList.add('${p.identifier.name}');
+                  }
+                });
+              }
+              var args = argList.join(', ');
+              proxy = [
+                '    if (!_deferredModule._isLoaded) {',
+                '      _deferredModule.load();',
+                '    }',
+                '    var module = await _loaded;',
+                '    return module.api.$name($args);'
+              ].join('\n');
+            } else {
+              proxy =
+                  '    throw new StateError(\'$moduleName has not yet been loaded.\');';
+            }
+            apiBuffer.writeln('  ${copyClassMember(member, proxy)}');
+          }
+        });
+      }
+      apiBuffer..writeln('}')..writeln();
+
+      tf.replace(getSpanForNode(sf, apiGetter),
+          '$apiTypeName get api /* GENERATED */ => _api;');
+      tf.insert(sf.location(sf.length), apiBuffer.toString());
+    }
+
+    // STEP 3:
+    // -------
+    // Generate a deferred proxy for the Components class.
+
+    if (hasComponents) {
+      StringBuffer sb = new StringBuffer()
+        ..write('${componentsGetter.returnType.name.name} get components { ')
+        ..write('/* GENERATED */ ')
+        ..write('_verifyIsLoaded(); ')
+        ..write('return _actual.components; ')
+        ..write('}');
+
+      tf.replace(getSpanForNode(sf, componentsGetter), sb.toString());
+    }
+
+    // STEP 4:
+    // -------
+    // Generate a deferred proxy for the Events class.
+
+    if (hasEvents) {
+      var eventsBuffer = new StringBuffer()..writeln();
+      var eventsTypeName = eventsGetter.returnType.name.name;
+
+      var eventsDecl = _deferrableModuleEventsDeclarations[moduleName];
+      if (eventsDecl == null) {
+        transform.logger.error(
+            'The $moduleName module has an Events class but it could not be '
+            'found - make sure it is annotated with '
+            '@DeferrableModuleEvents(\'$moduleName\').');
+      } else {
+        var dispatchKeyName = '_dispatchKey$deferredEventsClassName';
+        eventsBuffer
+          ..writeln(
+              'DispatchKey $dispatchKeyName = new DispatchKey(\'$deferredEventsClassName\');')
+          ..writeln(
+              'class $deferredEventsClassName implements $eventsTypeName {')
+          ..writeln('  Future _loaded;');
+
+        Iterable<FieldDeclaration> streams =
+            eventsDecl.node.members.where((f) => f is FieldDeclaration);
+        streams.forEach((stream) {
+          var name = stream.fields.variables.first.name.name;
+          var type = stream.fields.type;
+          eventsBuffer
+            ..writeln('  final $type $name = new $type($dispatchKeyName);');
+        });
+
+        eventsBuffer
+          ..writeln('  $deferredEventsClassName(this._loaded) {')
+          ..writeln('    _loaded.then((module) {');
+        streams.forEach((stream) {
+          var name = stream.fields.variables.first.name.name;
+          eventsBuffer
+            ..writeln('      module.events.$name.listen((event) {')
+            ..writeln('        $name(event, $dispatchKeyName);')
+            ..writeln('      });');
+        });
+        eventsBuffer
+          ..writeln('    });')
+          ..writeln('  }')
+          ..writeln('}')
+          ..writeln();
+      }
+
+      tf.replace(getSpanForNode(sf, eventsGetter),
+          '$eventsTypeName get events /* GENERATED */ => _events;');
+      tf.insert(sf.location(sf.length), eventsBuffer.toString());
+    }
+
+    // Step 5:
+    // -------
+    // Generate a mixin for the deferred module implementation.
+
+    List<String> generatedVars = [
+      '_actual',
+      '_api',
+      '_constructorCalled',
+      '_events',
+      '_isLoaded',
+      '_loaded',
+    ];
+
+    StringBuffer mixinBuffer = new StringBuffer()
+      ..writeln()
+      ..writeln('abstract class $deferredModuleMixinClassName {')
+      ..writeln('  _init() {')
+      ..writeln('    _isLoaded = false;')
+      ..writeln('    _loaded = new Completer();')
+      ..writeln('    _api = new $deferredApiClassName(_loaded.future, this);')
+      ..writeln('    _events = new $deferredEventsClassName(_loaded.future);')
+      ..writeln('  }');
+
+    // TODO: Verify that these constructors don't have initializers or bodies and are only stubs!!!
+
+    if (defaultCtor == null && namedCtors.isEmpty) {
+      // No constructors defined, so define an empty default constructor.
+      var defaultCtorStr = '$deferredModuleClassName() { '
+          '/* GENERATED */ '
+          '_init(); '
+          '_constructorCalled = \'\'; '
+          '}';
+
+      mixinBuffer
+        ..writeln('  _construct() {')
+        ..writeln('    _actual = new $deferredLibrary.$moduleName();')
+        ..writeln('  }');
+
+      tf.replace(getSpanForNode(sf, defaultCtor), defaultCtorStr.toString());
+    } else {
+      if (defaultCtor != null) {
+        var ctorVarPrefix = '_${deferredModuleClassName}_';
+        StringBuffer defaultCtorBuffer = new StringBuffer();
+        defaultCtor.parameters.parameters.forEach((param) {
+          generatedVars.add('$ctorVarPrefix${param.identifier.name}');
+        });
+
+        var ctorParams = defaultCtor.parameters.toString();
+        defaultCtorBuffer
+          ..write('$deferredModuleClassName$ctorParams { ')
+          ..write('/* GENERATED */ ')
+          ..write('_init(); ')
+          ..write('_constructorCalled = \'\'; ');
+
+        defaultCtor.parameters.parameters.forEach((param) {
+          defaultCtorBuffer.write(
+              '$ctorVarPrefix${param.identifier.name} = ${param.identifier.name}; ');
+        });
+
+        defaultCtorBuffer.write('}');
+
+        var argList = [];
+        defaultCtor.parameters.parameters.forEach((p) {
+          if (p.kind == ParameterKind.NAMED) {
+            argList.add(
+                '${p.identifier.name}: $ctorVarPrefix${p.identifier.name}');
+          } else {
+            argList.add('$ctorVarPrefix${p.identifier.name}');
+          }
+        });
+        var args = argList.join(', ');
+        mixinBuffer
+          ..writeln()
+          ..writeln('  _construct() {')
+          ..writeln('    _actual = new $deferredLibrary.$moduleName($args);')
+          ..writeln('  }');
+
+        tf.replace(
+            getSpanForNode(sf, defaultCtor), defaultCtorBuffer.toString());
+      }
+
+      if (namedCtors.isNotEmpty) {
+        namedCtors.forEach((ctor) {
+          var ctorVarPrefix = '_${deferredModuleClassName}_${ctor.name.name}_';
+          StringBuffer ctorBuffer = new StringBuffer();
+          ctor.parameters.parameters.forEach((param) {
+            generatedVars.add('$ctorVarPrefix${param.identifier.name}');
+          });
+
+          var ctorParams = ctor.parameters.toString();
+          ctorBuffer
+            ..write('$deferredModuleClassName.${ctor.name.name}$ctorParams { ')
+            ..write('/* GENERATED */ ')
+            ..write('_init(); ')
+            ..write('_constructorCalled = \'${ctor.name.name}\'; ');
+
+          ctor.parameters.parameters.forEach((param) {
+            ctorBuffer.write(
+                '$ctorVarPrefix${param.identifier.name} = ${param.identifier.name}; ');
+          });
+
+          ctorBuffer.write('}');
+
+          var argList = [];
+          defaultCtor.parameters.parameters.forEach((p) {
+            if (p.kind == ParameterKind.NAMED) {
+              argList.add(
+                  '${p.identifier.name}: $ctorVarPrefix${p.identifier.name}');
+            } else {
+              argList.add('$ctorVarPrefix${p.identifier.name}');
+            }
+          });
+          var args = argList.join(', ');
+          mixinBuffer
+            ..writeln()
+            ..writeln('  _construct${ctor.name.name}() {')
+            ..writeln(
+                '    _actual = new $deferredLibrary.$moduleName.${ctor.name.name}($args);')
+            ..writeln('  }');
+
+          tf.replace(getSpanForNode(sf, ctor), ctorBuffer.toString());
+        });
+      }
+    }
+
+    var generatedVarsStr = '/* GENERATED */ var ${generatedVars.join(', ')};';
+    tf.insert(
+        sf.location(deferredModuleNode.leftBracket.end), generatedVarsStr);
+
+    mixinBuffer
+      ..writeln()
+      ..writeln('  _constructActualModule() {')
+      ..writeln('    if (_constructorCalled == \'\') {')
+      ..writeln('      _construct();')
+      ..writeln('    }');
+
+    if (namedCtors.isNotEmpty) {
+      namedCtors.forEach((ctor) {
+        mixinBuffer
+          ..writeln('    if (_constructorCalled == \'${ctor.name.name}\') {')
+          ..writeln('      _construct${ctor.name.name}();')
+          ..writeln('    }');
+      });
+    }
+
+    mixinBuffer.writeln('  }');
+
+    mixinBuffer
+      ..writeln()
+      ..writeln('  @override')
+      ..writeln('  onLoad() async {')
+      ..writeln('    if (_isLoaded) return;')
+      ..writeln('    await $deferredLibrary.loadLibrary();')
+      ..writeln('    if (_isLoaded) return;')
+      ..writeln('    _constructActualModule();')
+      ..writeln('    _isLoaded = true;')
+      ..writeln('    _loaded.complete(_actual);')
+      ..writeln('  }')
+      ..writeln()
+      ..writeln('  @override')
+      ..writeln('  onUnload() {')
+      ..writeln('    _verifyIsLoaded();')
+      ..writeln('    return _actual.shouldUnload();')
+      ..writeln('  }')
+      ..writeln()
+      ..writeln('  void _verifyIsLoaded() {')
+      ..writeln('    if (!_isLoaded) throw new StateError(')
+      ..writeln(
+          '        \'Cannot access deferred module until it has been loaded.\');')
+      ..writeln('  }')
+      ..writeln();
+
+    for (var generatedVar in generatedVars) {
+      mixinBuffer..writeln('  get $generatedVar; set $generatedVar(v);');
+    }
+
+    mixinBuffer..writeln('}')..writeln();
+
+    tf.insert(sf.location(sf.length), mixinBuffer.toString());
+
+    // Step 6:
+    // -------
+    // Transform the deferred module class to use the generated mixin.
+
+    if (deferredModuleNode.extendsClause == null) {
+      // No extends clause, no with clause.
+      var extendsWithClause =
+          'extends Object with $deferredModuleMixinClassName';
+      if (deferredModuleNode.implementsClause != null) {
+        // Has implements clause, so insert right before it.
+        tf.insert(sf.location(deferredModuleNode.implementsClause.offset),
+            extendsWithClause);
+      } else {
+        // No implements clause, so insert right before left bracket.
+        tf.insert(sf.location(deferredModuleNode.leftBracket.offset),
+            extendsWithClause);
+      }
+    } else if (deferredModuleNode.withClause == null) {
+      // Has extends clause, but no with clause, so insert after extends.
+      tf.insert(sf.location(deferredModuleNode.extendsClause.end),
+          ' with $deferredModuleMixinClassName');
+    } else {
+      // Has extends clause and with clause, so add to the with clause.
+      tf.insert(sf.location(deferredModuleNode.withClause.end),
+          ', $deferredModuleMixinClassName');
+    }
+
+    // Step 7:
+    // -------
+    // Add the transformed output.
+
+    if (tf.isModified) {
+      transform
+          .addOutput(new Asset.fromString(assetId, tf.getTransformedText()));
+    }
+
+    if (settings.mode == BarbackMode.DEBUG) {
+      transform.addOutput(new Asset.fromString(
+          assetId.addExtension('.diff.html'), tf.getHtmlDiff()));
+    }
+  }
+
+  void _validate() {
+    // Warn about modules marked as "deferrable" with no corresponding deferred
+    // module class.
+    for (String moduleName in _deferrableModuleNames) {
+      if (!_deferredModuleDeclarations.containsKey(moduleName)) {
+        transform.logger.error(
+            '@DeferrableModule annotation expects a class with a correlating '
+            '@DeferredModule annotation, but one was not found.');
+      }
+    }
+
+    // Warn about modules marked as "deferred" with no corresponding real module
+    // class.
+    for (String moduleName in _deferredModuleDeclarations.keys) {
+      if (!_deferrableModuleNames.contains(moduleName)) {
+        transform.logger.error(
+            '@DeferredModule annotation expects a $moduleName class with a '
+            'correlating @DeferrableModule annotation, but one was not found.');
+      }
+    }
+
+    // TODO: warn about deferred modules with API but missing API annotation
+    // TODO: warn about deferred modules with Events but missing Events annotation
+  }
+}

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -20,7 +20,7 @@ import 'dart:async';
 /// unified lifecycle API.
 abstract class LifecycleModule {
   /// Name of the module for identification within exceptions and while debugging.
-  String name = 'Module';
+  String get name => 'Module';
 
   /// List of child components so that lifecycle can iterate over them as needed
   List<LifecycleModule> _childModules = [];

--- a/lib/w_module.dart
+++ b/lib/w_module.dart
@@ -21,6 +21,6 @@
 /// facilitates dynamic loading / unloading of modules.
 library w_module;
 
-export 'src/event.dart';
-export 'src/lifecycle_module.dart';
-export 'src/module.dart';
+export 'package:w_module/src/event.dart';
+export 'package:w_module/src/lifecycle_module.dart';
+export 'package:w_module/src/module.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,12 @@ authors:
   - Max Peterson <maxwell.peterson@workiva.com>
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/w_module
+dependencies:
+  barback: "^0.15.2"
+  transformer_utils:
+    git:
+      url: git@github.com:Workiva/dart_transformer_utils.git
+      ref: master
 dev_dependencies:
   browser: "^0.10.0+2"
   browser_detect: "^1.0.3"
@@ -22,3 +28,5 @@ dev_dependencies:
   w_flux: "^1.0.0"
 environment:
   sdk: ">=1.9.0 <2.0.0"
+transformers:
+- w_module/alpha/deferred_module_transformer

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,10 +11,7 @@ authors:
 homepage: https://github.com/Workiva/w_module
 dependencies:
   barback: "^0.15.2"
-  transformer_utils:
-    git:
-      url: git@github.com:Workiva/dart_transformer_utils.git
-      ref: master
+  transformer_utils: "^0.1.1"
 dev_dependencies:
   browser: "^0.10.0+2"
   browser_detect: "^1.0.3"

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -20,7 +20,14 @@ main(List<String> args) async {
   // https://github.com/Workiva/dart_dev
 
   List<String> directories = ['example/', 'lib/', 'test/', 'tool/'];
-  config.analyze.entryPoints = directories;
+  config.analyze.entryPoints = [
+    'example/deferred/',
+    'example/panel/',
+    'example/random_color/',
+    'lib/',
+    'test/',
+    'tool/'
+  ];
   config.copyLicense.directories = directories;
   config.format.directories = directories;
 


### PR DESCRIPTION
## Issue
- Need a way to create deferred versions of modules with as little effort as possible and without the need to recreate the deferred module loading logic in the module lifecycle.

## Changes
**Source:**
- Use a pub transformer to generate the deferred module implementation.
- Generates getters for API, Components, and Events
  - The API is wrapped such that any calls to the API triggers the loading of the module (if not already loaded). If the targeted API method is async or if the getter returned a Future, it will be proxied to the real module API once loaded. If it is sync, it will throw if the module had not yet been loaded.
  - The Events are all proxied to allow listener registration immediately.
  - The Components are wrapped but will throw if the module has not yet been loaded. Components that need to be available before the module has been loaded should be made available statically.
- Generates constructor bodies that store the args and proxy them to the real constructor when called
- Generates the module lifecycle implementations that loads the deferred library during the "onLoad" event

## Usage
**THIS WILL BE RELEASED AS AN ALPHA FEATURE.** API, code, and general approach is subject to change based on usage. 

- To import the annotations:

    ```dart
    import 'package:w_module/alpha.dart';
    ```
- To use the transformer, add this to your `pubspec.yaml`:

    ```yaml
    transformers:
    - w_module/alpha/deferred_module_transformer
    ```

## Testing
- Serve the examples and load the deferred module example
- The counter_module.dart file should not be loaded until one of the two buttons is clicked
- Both versions of the counter module should work as expected

## Code Review
@greglittlefield-wf 
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 