### PR TITLE
CP-1047 Release w_module 0.3.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_module
-version: 0.3.1
+version: 0.3.2
 description: Base module classes with a well defined lifecycle for modular Dart applications.
 authors:
   - Workiva Client Platform Team <team-clientplatform@workiva.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1047

JIRA and PR's included in this release: 


 CP-1162  - Use completers instead of async/await so tests work in Dart 1.13  - https://github.com/Workiva/w_module/pull/41
 CP-1166  - Dart formatter updates for w_module, dart_style 0.2.1.  - https://github.com/Workiva/w_module/pull/42
 CP-1174  - Add Child Modules Getter to LifecycleModule  - https://github.com/Workiva/w_module/pull/38

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_module/compare/0.3.1...CP-1047_release_0.3.2

