### PR TITLE
CP-2082 Revert breaking change to LifecycleModule.name

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -20,7 +20,7 @@ import 'dart:async';
 /// unified lifecycle API.
 abstract class LifecycleModule {
   /// Name of the module for identification within exceptions and while debugging.
-  String get name => 'Module';
+  String name = 'Module';
 
   /// List of child components so that lifecycle can iterate over them as needed
   List<LifecycleModule> _childModules = [];


### PR DESCRIPTION
## Issue
The deferred module PR that was merged a while back (#40) inadvertently introduced a breaking change by changing `LifecycleModule.name` from a property to a getter. Any module using the `name` setter would be affected by this.

## Solution
Revert to property so that it has a setter and getter.

_Long term, I think it makes more sense for it to just be a getter (consumers should override the getter instead of setting the value elsewhere), but we'll have to do that in a proper breaking change release._

## Testing
- [ ] CI passes
- [ ] Code matches the previous release (0.3.2)

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 
@srinivasdhanwada-wf 