### PR TITLE
CP-2089 Updated README to use Github raw content url

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## Overview
 
-![module-diagram](https://github.com/Workiva/w_module/blob/images/images/w_module_diagram.png)
+![module-diagram](https://raw.githubusercontent.com/Workiva/w_module/images/images/w_module_diagram.png)
 
 `w_module` implements a module encapsulation and lifecycle pattern for Dart that interfaces well with the application
 architecture defined in the [w_flux](https://github.com/Workiva/w_flux) library.  `w_module` defines the public interface


### PR DESCRIPTION
This way it also shows on pub: https://pub.dartlang.org/packages/w_module

(Requires a pushing a +N version bump on pub, eg 0.3.4+1, for it to show)