### PR TITLE
REF-1267 Add suspend / resume semantics

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -16,6 +16,8 @@ library w_module.src.lifecycle_module;
 
 import 'dart:async';
 
+import 'package:logging/logging.dart';
+
 /// Intended to be extended by most base module classes in order to provide a
 /// unified lifecycle API.
 abstract class LifecycleModule {
@@ -35,14 +37,6 @@ abstract class LifecycleModule {
   /// Event dispatched at end of module.load() logic
   StreamController<LifecycleModule> _didLoadController;
   Stream<LifecycleModule> get didLoad => _didLoadController.stream;
-
-  /// Event dispatched at beginning of module.unload() logic
-  StreamController<LifecycleModule> _willUnloadController;
-  Stream<LifecycleModule> get willUnload => _willUnloadController.stream;
-
-  /// Event dispatched at end of module.unload() logic
-  StreamController<LifecycleModule> _didUnloadController;
-  Stream<LifecycleModule> get didUnload => _didUnloadController.stream;
 
   /// Event dispatched at the beginning of module.loadChildModule() logic
   StreamController<LifecycleModule> _willLoadChildModuleController;
@@ -64,10 +58,40 @@ abstract class LifecycleModule {
   Stream<LifecycleModule> get didUnloadChildModule =>
       _didUnloadChildModuleController.stream;
 
+  /// Event dispatched at the beginning of the module.suspend() logic
+  StreamController<LifecycleModule> _willSuspendController;
+  Stream<LifecycleModule> get willSuspend => _willSuspendController.stream;
+
+  /// Event dispatched at the end of the module.suspend() logic
+  StreamController<LifecycleModule> _didSuspendController;
+  Stream<LifecycleModule> get didSuspend => _didSuspendController.stream;
+
+  /// Event dispatched at the beginning of the module.resume() logic
+  StreamController<LifecycleModule> _willResumeController;
+  Stream<LifecycleModule> get willResume => _willResumeController.stream;
+
+  /// Event dispatched at the end of the module.resume() logic
+  StreamController<LifecycleModule> _didResumeController;
+  Stream<LifecycleModule> get didResume => _didResumeController.stream;
+
+  /// Event dispatched at beginning of module.unload() logic
+  StreamController<LifecycleModule> _willUnloadController;
+  Stream<LifecycleModule> get willUnload => _willUnloadController.stream;
+
+  /// Event dispatched at end of module.unload() logic
+  StreamController<LifecycleModule> _didUnloadController;
+  Stream<LifecycleModule> get didUnload => _didUnloadController.stream;
+
   final Map<LifecycleModule, StreamSubscription<LifecycleModule>>
       _willUnloadChildModuleSubscriptions = {};
   final Map<LifecycleModule, StreamSubscription<LifecycleModule>>
       _didUnloadChildModuleSubscriptions = {};
+
+  bool _isLoaded = false;
+
+  bool _isSuspended = false;
+
+  Logger _logger;
 
   // constructor necessary to init load / unload state stream
   LifecycleModule() {
@@ -83,7 +107,21 @@ abstract class LifecycleModule {
         new StreamController<LifecycleModule>.broadcast();
     _didUnloadChildModuleController =
         new StreamController<LifecycleModule>.broadcast();
+    _willSuspendController = new StreamController<LifecycleModule>.broadcast();
+    _didSuspendController = new StreamController<LifecycleModule>.broadcast();
+    _willResumeController = new StreamController<LifecycleModule>.broadcast();
+    _didResumeController = new StreamController<LifecycleModule>.broadcast();
+
+    _logger = new Logger('w_module');
   }
+
+  /// Whether the module is currently loaded.
+  bool get isLoaded => _isLoaded;
+
+  /// Whether the module is currently suspended.
+  ///
+  /// This will always be false when the module is not loaded.
+  bool get isSuspended => _isSuspended;
 
   //--------------------------------------------------------
   // Public methods that can be used directly to trigger
@@ -91,15 +129,23 @@ abstract class LifecycleModule {
   //--------------------------------------------------------
 
   /// Public method to trigger the loading of a Module.
+  ///
   /// Calls the onLoad() method, which can be implemented on a Module.
   /// Executes the willLoad and didLoad event streams.
+  /// TODO: Do we want to support re-loading of child modules here?
   Future load() {
     Completer completer = new Completer();
-    _willLoadController.add(this);
-    onLoad().then((_) {
-      _didLoadController.add(this);
+    if (!_isLoaded) {
+      _willLoadController.add(this);
+      onLoad().then((_) {
+        _didLoadController.add(this);
+        _isLoaded = true;
+        completer.complete();
+      });
+    } else {
+      _logger.warning('Module "$name" is already loaded, cannot load.');
       completer.complete();
-    });
+    }
     return completer.future;
   }
 
@@ -136,7 +182,55 @@ abstract class LifecycleModule {
     return completer.future;
   }
 
+  /// Public method to suspend the module.
+  ///
+  /// Suspend indicates to the module that it should go into a low-activity
+  /// state. For example, by disconnecting from backend services and unloading
+  /// heavy data structures.
+  Future suspend() {
+    Completer completer = new Completer();
+    if (!_isSuspended && _isLoaded) {
+      _willSuspendController.add(this);
+      Future.wait(_childModules.map((c) => c.suspend())).then((_) {
+        onSuspend().then((_) {
+          _didSuspendController.add(this);
+          _isSuspended = true;
+          completer.complete();
+        });
+      });
+    } else {
+      _logger.warning(
+          'Module "$name" is ${_isLoaded ? 'already suspended' : 'not loaded'}, cannot suspend.');
+      completer.complete();
+    }
+    return completer.future;
+  }
+
+  /// Public method to resume the module.
+  ///
+  /// This should put the module back into its normal state after the module
+  /// was suspended.
+  Future resume() {
+    Completer completer = new Completer();
+    if (_isSuspended && _isLoaded) {
+      _willResumeController.add(this);
+      Future.wait(_childModules.map((c) => c.resume())).then((_) {
+        onResume().then((_) {
+          _didResumeController.add(this);
+          _isSuspended = false;
+          completer.complete();
+        });
+      });
+    } else {
+      _logger.warning(
+          'Module "$name" is ${_isLoaded ? 'not suspended' : 'not loaded'}, cannot suspend.');
+      completer.complete();
+    }
+    return completer.future;
+  }
+
   /// Public method to query the unloadable state of the Module.
+  ///
   /// Calls the onShouldUnload() method, which can be implemented on a Module.
   /// onShouldUnload is also called on all registered child modules.
   ShouldUnloadResult shouldUnload() {
@@ -159,25 +253,33 @@ abstract class LifecycleModule {
   }
 
   /// Public method to trigger the Module unload cycle.
+  ///
   /// Calls shouldUnload(), and, if that completes successfully,
   /// continues to call onUnload() on the module and all registered child modules.
   /// If unloading is rejected, this method will complete with an error.
   Future unload() {
     Completer completer = new Completer();
-    ShouldUnloadResult canUnload = shouldUnload();
-    if (canUnload.shouldUnload) {
-      _willUnloadController.add(this);
-      Iterable<Future> unloadChildren = _childModules.map((c) => c.unload());
-      Future.wait(unloadChildren).then((_) {
-        _childModules.clear();
-        onUnload().then((_) {
-          _didUnloadController.add(this);
-          completer.complete();
+    if (_isLoaded) {
+      ShouldUnloadResult canUnload = shouldUnload();
+      if (canUnload.shouldUnload) {
+        _willUnloadController.add(this);
+        Iterable<Future> unloadChildren = _childModules.map((c) => c.unload());
+        Future.wait(unloadChildren).then((_) {
+          _childModules.clear();
+          onUnload().then((_) {
+            _didUnloadController.add(this);
+            _isLoaded = false;
+            _isSuspended = false;
+            completer.complete();
+          });
         });
-      });
+      } else {
+        // reject with shouldUnload messages
+        throw new ModuleUnloadCanceledException(canUnload.messagesAsString());
+      }
     } else {
-      // reject with shouldUnload messages
-      throw new ModuleUnloadCanceledException(canUnload.messagesAsString());
+      _logger.warning('Module "$name" is already unloaded, cannot unload.');
+      completer.complete();
     }
     return completer.future;
   }
@@ -187,6 +289,13 @@ abstract class LifecycleModule {
   // to execute code during certain phases of the module
   // lifecycle
   //--------------------------------------------------------
+
+  /// Custom logic to be executed during load.
+  ///
+  /// Initial data queries and interactions with the server can be triggered
+  /// here.  Returns a future with no payload that completes when the module has
+  /// finished loading.
+  Future onLoad() async {}
 
   /// Custom logic to be executed when a child module is to be loaded.
   Future onWillLoadChildModule(LifecycleModule module) async {}
@@ -200,13 +309,19 @@ abstract class LifecycleModule {
   /// Custom logic to be executed when a child module has been unloaded.
   Future onDidUnloadChildModule(LifecycleModule module) async {}
 
-  /// Custom logic to be executed during load.
-  /// Initial data queries and interactions with the server can be triggered
-  /// here.  Returns a future with no payload that completes when the module has
-  /// finished loading.
-  Future onLoad() async {}
+  /// Custom logic to be executed during suspend.
+  ///
+  /// Server connections can be dropped and large data structures unloaded here.
+  /// Nothing should be done here that cannot be undone in [onResume].
+  Future onSuspend() async {}
+
+  /// Custom logic to be executed during resume.
+  ///
+  /// Any changes made in [onSuspend] can be reverted here.
+  Future onResume() async {}
 
   /// Custom logic to be executed during shouldUnload (consequently also in unload).
+  ///
   /// Returns a ShouldUnloadResult.
   /// [ShouldUnloadResult.shouldUnload == true] indicates that the module is safe to unload.
   /// [ShouldUnloadResult.shouldUnload == false] indicates that the module should not be unloaded.
@@ -217,6 +332,7 @@ abstract class LifecycleModule {
   }
 
   /// Custom logic to be executed during unload.
+  ///
   /// Called on unload if shouldUnload completes with true. This can be used for
   /// cleanup. Returns a future with no payload that completes when the module
   /// has finished unloading.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,8 @@ authors:
   - Max Peterson <maxwell.peterson@workiva.com>
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/w_module
+dependencies:
+  logging: "^0.11.0"
 dev_dependencies:
   browser: "^0.10.0+2"
   browser_detect: "^1.0.3"


### PR DESCRIPTION
## Problem

We need some concept of suspend / resume for other projects. It seems to make sense to add it here, at the lowest level.

## Solution

Add it. I added a few new bits:

  * `isLoaded` - whether the module is loaded, if they're allowed to be toggled, this seems like a good idea
  * `isSuspended` - this can be toggled, so it's nice to have a getter
  * `onSuspend` - called when we suspend
  * `onResume` - called when we resume
  * `willSuspend`, `didSuspend` - dispatched before and after we suspend
  * `willResume`, `didResume` - dispatched before and after we resume

I also added a `Logger` and added warnings in the following cases:

  * Loading an already-loaded module
  * Unloading a modules that has already been unloaded or was never loaded to begin with
  * Suspending an already-suspended module
  * Suspending a module that is not loaded
  * Resuming a module that is not suspended
  * Resuming a module that is not loaded

I updated the README to reflect the new features.

## Potential Regressions

Module load / unload.

## Tests

Added and/or updated.

## QA / +10

1. Checkout the branch.
2. Update dependencies.
3. Unit tests should pass.
4. CI passes.
5. No errors in examples.

## FYI

@Workiva/ref-pp @evanweible-wf @maxwellpeterson-wf @trentgrover-wf @dustinlessard-wf 