### PR TITLE
CP-2683 Enable strong-mode/linter. Use `@protected` annotation.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,63 @@
+analyzer:
+  strong-mode: true
+
+linter:
+  rules:
+    # Error Rules
+    - avoid_empty_else
+    - comment_references
+    - control_flow_in_finally
+    - empty_statements
+    - hash_and_equals
+    - invariant_booleans
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - literal_only_boolean_expressions
+    - test_types_in_equals
+    - throw_in_finally
+    - unrelated_type_equality_checks
+    - valid_regexps
+
+    # TODO: enable these when addressing memory audit/disposables
+    #- cancel_subscriptions
+    #- close_sinks
+
+    # Style Rules
+    - always_declare_return_types
+    - annotate_overrides
+    - avoid_as
+    - avoid_init_to_null
+    - avoid_return_types_on_setters
+    - await_only_futures
+    - camel_case_types
+    - constant_identifier_names
+    - empty_catches
+    - empty_constructor_bodies
+    - implementation_imports
+    - library_names
+    - library_prefixes
+    - non_constant_identifier_names
+    - one_member_abstracts
+    - only_throw_errors
+    - overridden_fields
+    - package_api_docs
+    - package_prefixed_library_names
+    - prefer_is_not_empty
+    - slash_for_doc_comments
+    - sort_constructors_first
+    - sort_unnamed_constructors_first
+    - super_goes_last
+    - type_annotate_public_apis
+    - type_init_formals
+    - unawaited_futures
+    - unnecessary_brace_in_string_interp
+    - unnecessary_getters_setters
+
+    # TODO
+    #- public_member_api_docs
+
+    # This rule forces overly verbose declaration of variables.
+    #- always_specify_types
+
+    # Pub Rules
+    - package_names

--- a/example/panel/modules/basic_module.dart
+++ b/example/panel/modules/basic_module.dart
@@ -18,18 +18,22 @@ import 'package:react/react.dart' as react;
 import 'package:w_module/w_module.dart';
 
 class BasicModule extends Module {
+  @override
   final String name = 'BasicModule';
 
   BasicModuleComponents _components;
-  BasicModuleComponents get components => _components;
 
   BasicModule() {
     _components = new BasicModuleComponents();
   }
+
+  @override
+  BasicModuleComponents get components => _components;
 }
 
 class BasicModuleComponents implements ModuleComponents {
-  content() => react.div({
+  @override
+  Object content() => react.div({
         'style': {
           'padding': '50px',
           'backgroundColor': 'lightgray',

--- a/example/panel/modules/data_load_async_module.dart
+++ b/example/panel/modules/data_load_async_module.dart
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_module.example.panel.modules.dataLoadAsync_module;
+library w_module.example.panel.modules.data_load_async_module;
 
 import 'dart:async';
 
-import 'package:w_flux/w_flux.dart';
+import 'package:meta/meta.dart' show protected;
 import 'package:react/react.dart' as react;
+import 'package:w_flux/w_flux.dart';
 import 'package:w_module/w_module.dart';
 
 class DataLoadAsyncModule extends Module {
+  @override
   final String name = 'DataLoadAsyncModule';
 
   DataLoadAsyncActions _actions;
-  DataLoadAsyncStore _stores;
-
   DataLoadAsyncComponents _components;
-  DataLoadAsyncComponents get components => _components;
+  DataLoadAsyncStore _stores;
 
   DataLoadAsyncModule() {
     _actions = new DataLoadAsyncActions();
@@ -35,9 +35,15 @@ class DataLoadAsyncModule extends Module {
     _components = new DataLoadAsyncComponents(_actions, _stores);
   }
 
-  Future onLoad() async {
+  @override
+  DataLoadAsyncComponents get components => _components;
+
+  @override
+  @protected
+  Future<Null> onLoad() {
     // trigger non-blocking async load of data
     _actions.loadData();
+    return new Future.value();
   }
 }
 
@@ -47,7 +53,9 @@ class DataLoadAsyncComponents implements ModuleComponents {
 
   DataLoadAsyncComponents(this._actions, this._stores);
 
-  content() => DataLoadAsyncComponent({'actions': _actions, 'store': _stores});
+  @override
+  Object content() =>
+      DataLoadAsyncComponent({'actions': _actions, 'store': _stores});
 }
 
 class DataLoadAsyncActions {
@@ -55,22 +63,22 @@ class DataLoadAsyncActions {
 }
 
 class DataLoadAsyncStore extends Store {
-  /// Public data
-  bool _isLoading;
-  bool get isLoading => _isLoading;
-  List<String> _data;
-  List<String> get data => _data;
-
-  /// Internals
   DataLoadAsyncActions _actions;
+  List<String> _data;
+  bool _isLoading;
 
-  DataLoadAsyncStore(DataLoadAsyncActions this._actions) {
+  DataLoadAsyncStore(this._actions) {
     _isLoading = false;
     _data = [];
     triggerOnAction(_actions.loadData, _loadData);
   }
 
-  _loadData(_) async {
+  /// Public data
+  List<String> get data => _data;
+
+  bool get isLoading => _isLoading;
+
+  Future<Null> _loadData(_) async {
     // set loading state and trigger to display loading spinner
     _isLoading = true;
     trigger();
@@ -84,12 +92,14 @@ class DataLoadAsyncStore extends Store {
   }
 }
 
-var DataLoadAsyncComponent =
+// ignore: non_constant_identifier_names
+Object DataLoadAsyncComponent =
     react.registerComponent(() => new _DataLoadAsyncComponent());
 
 class _DataLoadAsyncComponent
     extends FluxComponent<DataLoadAsyncActions, DataLoadAsyncStore> {
-  render() {
+  @override
+  Object render() {
     var content;
     if (store.isLoading) {
       content = react.div({'className': 'loader'}, 'Loading data...');

--- a/example/panel/modules/data_load_blocking_module.dart
+++ b/example/panel/modules/data_load_blocking_module.dart
@@ -12,27 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_module.example.panel.modules.dataLoadBlocking_module;
+library w_module.example.panel.modules.data_load_blocking_module;
 
 import 'dart:async';
 
+import 'package:meta/meta.dart' show protected;
 import 'package:react/react.dart' as react;
 import 'package:w_module/w_module.dart';
 
 class DataLoadBlockingModule extends Module {
-  final String name = 'DataLoadBlockingModule';
-
   List<String> data;
 
+  @override
+  final String name = 'DataLoadBlockingModule';
+
   DataLoadBlockingComponents _components;
-  DataLoadBlockingComponents get components => _components;
 
   DataLoadBlockingModule() {
     data = [];
     _components = new DataLoadBlockingComponents(this);
   }
 
-  Future onLoad() async {
+  @override
+  DataLoadBlockingComponents get components => _components;
+
+  @override
+  @protected
+  Future<Null> onLoad() async {
     // perform async load of data (fake it with a Future)
     await new Future.delayed(new Duration(seconds: 1));
     data = ['Grover', 'Hoffman', 'Lessard', 'Peterson', 'Udey', 'Weible'];
@@ -43,7 +49,8 @@ class DataLoadBlockingComponents implements ModuleComponents {
   DataLoadBlockingModule _module;
   DataLoadBlockingComponents(this._module);
 
-  content() {
+  @override
+  Object content() {
     int keyCounter = 0;
     return react.div({
       'style': {'padding': '50px', 'backgroundColor': 'red', 'color': 'white'}

--- a/example/panel/modules/deferred_heavy_lifter_implementation.dart
+++ b/example/panel/modules/deferred_heavy_lifter_implementation.dart
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_module.example.panel.modules.deferred_heavyLifter_implementation;
+library w_module.example.panel.modules.deferred_heavy_lifter_implementation;
 
-import './deferred_heavyLifter_interface.dart';
+import './deferred_heavy_lifter_interface.dart';
 
 class RealLifter implements HeavyLifter {
   HeavyLifterDivision _division;
-  HeavyLifterDivision get division => _division;
 
-  RealLifter(HeavyLifterDivision this._division);
+  RealLifter(this._division);
 
+  @override
   List<String> get competitors {
-    if (_division == HeavyLifterDivision.FEATHERWEIGHT) {
+    if (_division == HeavyLifterDivision.featherweight) {
       return [
         'SpongeBob SquarePants',
         'Patrick Star',
@@ -54,7 +54,7 @@ class RealLifter implements HeavyLifter {
         'Bubble Buddy',
         'DoodleBob'
       ];
-    } else if (_division == HeavyLifterDivision.WELTERWEIGHT) {
+    } else if (_division == HeavyLifterDivision.welterweight) {
       return [
         'Philip J. Fry',
         'Turanga Leela',
@@ -83,7 +83,7 @@ class RealLifter implements HeavyLifter {
         'Cubert Farnsworth',
         'Flexo'
       ];
-    } else if (_division == HeavyLifterDivision.HEAVYWEIGHT) {
+    } else if (_division == HeavyLifterDivision.heavyweight) {
       return [
         'Apollo Creed',
         'Rocky Balboa',
@@ -117,4 +117,7 @@ class RealLifter implements HeavyLifter {
     }
     return [];
   }
+
+  @override
+  HeavyLifterDivision get division => _division;
 }

--- a/example/panel/modules/deferred_heavy_lifter_interface.dart
+++ b/example/panel/modules/deferred_heavy_lifter_interface.dart
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_module.example.panel.modules.deferred_heavyLifter_interface;
+library w_module.example.panel.modules.deferred_heavy_lifter_interface;
 
-enum HeavyLifterDivision { FEATHERWEIGHT, WELTERWEIGHT, HEAVYWEIGHT }
+enum HeavyLifterDivision { featherweight, welterweight, heavyweight }
 
 class HeavyLifter {
   HeavyLifterDivision _division;
-  HeavyLifterDivision get division => _division;
 
-  HeavyLifter(HeavyLifterDivision this._division);
+  HeavyLifter(this._division);
 
   List<String> get competitors => [];
+
+  HeavyLifterDivision get division => _division;
 }

--- a/example/panel/modules/deferred_module.dart
+++ b/example/panel/modules/deferred_module.dart
@@ -16,28 +16,35 @@ library w_module.example.panel.modules.deferred_module;
 
 import 'dart:async';
 
+import 'package:meta/meta.dart' show protected;
 import 'package:react/react.dart' as react;
 import 'package:w_module/w_module.dart';
 
-import './deferred_heavyLifter_interface.dart';
-import './deferred_heavyLifter_implementation.dart'
-    deferred as HeavyLifterWithData;
+import './deferred_heavy_lifter_interface.dart';
+import './deferred_heavy_lifter_implementation.dart'
+    deferred as heavy_lifter_with_data;
 
 class DeferredModule extends Module {
-  final String name = 'DeferredModule';
-
   HeavyLifter data;
 
+  @override
+  final String name = 'DeferredModule';
+
   DeferredComponents _components;
-  DeferredComponents get components => _components;
 
   DeferredModule() {
     _components = new DeferredComponents(this);
   }
 
-  Future onLoad() async {
-    await HeavyLifterWithData.loadLibrary();
-    data = new HeavyLifterWithData.RealLifter(HeavyLifterDivision.HEAVYWEIGHT);
+  @override
+  DeferredComponents get components => _components;
+
+  @override
+  @protected
+  Future<Null> onLoad() async {
+    await heavy_lifter_with_data.loadLibrary();
+    data =
+        new heavy_lifter_with_data.RealLifter(HeavyLifterDivision.heavyweight);
   }
 }
 
@@ -45,7 +52,8 @@ class DeferredComponents implements ModuleComponents {
   DeferredModule _module;
   DeferredComponents(this._module);
 
-  content() {
+  @override
+  Object content() {
     int keyCounter = 0;
     return react.div({
       'style': {'padding': '50px', 'backgroundColor': 'blue', 'color': 'white'}

--- a/example/panel/modules/flux_module.dart
+++ b/example/panel/modules/flux_module.dart
@@ -21,19 +21,21 @@ import 'package:react/react.dart' as react;
 import 'package:w_module/w_module.dart';
 
 class FluxModule extends Module {
+  @override
   final String name = 'FluxModule';
 
   FluxActions _actions;
-  FluxStore _stores;
-
   FluxComponents _components;
-  FluxComponents get components => _components;
+  FluxStore _stores;
 
   FluxModule() {
     _actions = new FluxActions();
     _stores = new FluxStore(_actions);
     _components = new FluxComponents(_actions, _stores);
   }
+
+  @override
+  FluxComponents get components => _components;
 }
 
 class FluxComponents implements ModuleComponents {
@@ -42,7 +44,8 @@ class FluxComponents implements ModuleComponents {
 
   FluxComponents(this._actions, this._stores);
 
-  content() => MyFluxComponent({'actions': _actions, 'store': _stores});
+  @override
+  Object content() => MyFluxComponent({'actions': _actions, 'store': _stores});
 }
 
 class FluxActions {
@@ -50,28 +53,28 @@ class FluxActions {
 }
 
 class FluxStore extends Store {
-  /// Public data
-  String _backgroundColor = 'gray';
-  String get backgroundColor => _backgroundColor;
-
-  /// Internals
   FluxActions _actions;
+  String _backgroundColor = 'gray';
 
-  FluxStore(FluxActions this._actions) {
+  FluxStore(this._actions) {
     triggerOnAction(_actions.changeBackgroundColor, _changeBackgroundColor);
   }
 
-  _changeBackgroundColor(_) {
+  String get backgroundColor => _backgroundColor;
+
+  void _changeBackgroundColor(_) {
     // generate a random hex color string
     _backgroundColor =
         '#' + (new Random().nextDouble() * 16777215).floor().toRadixString(16);
   }
 }
 
-var MyFluxComponent = react.registerComponent(() => new _MyFluxComponent());
+// ignore: non_constant_identifier_names
+Object MyFluxComponent = react.registerComponent(() => new _MyFluxComponent());
 
 class _MyFluxComponent extends FluxComponent<FluxActions, FluxStore> {
-  render() {
+  @override
+  Object render() {
     return react.div({
       'style': {
         'padding': '50px',

--- a/example/panel/modules/hierarchy_module.dart
+++ b/example/panel/modules/hierarchy_module.dart
@@ -17,26 +17,26 @@ library w_module.example.panel.modules.hierarchy_module;
 import 'dart:async';
 import 'dart:html';
 
+import 'package:meta/meta.dart' show protected;
+import 'package:react/react.dart' as react;
 import 'package:w_module/w_module.dart';
 import 'package:w_flux/w_flux.dart';
-import 'package:react/react.dart' as react;
 
 import './basic_module.dart';
 import './flux_module.dart';
 import './reject_module.dart';
-import './dataLoadAsync_module.dart';
-import './dataLoadBlocking_module.dart';
+import './data_load_async_module.dart';
+import './data_load_blocking_module.dart';
 import './deferred_module.dart';
-import './lifecycleEcho_module.dart';
+import './lifecycle_echo_module.dart';
 
 class HierarchyModule extends Module {
+  @override
   final String name = 'HierarchyModule';
 
   HierarchyActions _actions;
-  HierarchyStore _stores;
-
   HierarchyComponents _components;
-  HierarchyComponents get components => _components;
+  HierarchyStore _stores;
 
   HierarchyModule() {
     _actions = new HierarchyActions();
@@ -44,7 +44,12 @@ class HierarchyModule extends Module {
     _components = new HierarchyComponents(_actions, _stores);
   }
 
-  Future onLoad() async {
+  @override
+  HierarchyComponents get components => _components;
+
+  @override
+  @protected
+  Future<Null> onLoad() async {
     // can optionally await all of the loadModule calls
     // to force all children to load before this module
     // completes loading (not recommended)
@@ -74,7 +79,9 @@ class HierarchyComponents implements ModuleComponents {
 
   HierarchyComponents(this._actions, this._stores);
 
-  content() => HierarchyComponent({'actions': _actions, 'store': _stores});
+  @override
+  Object content() =>
+      HierarchyComponent({'actions': _actions, 'store': _stores});
 }
 
 class HierarchyActions {
@@ -83,23 +90,21 @@ class HierarchyActions {
 }
 
 class HierarchyStore extends Store {
-  /// Public data
-  List<Module> _childModules = [];
-  List<Module> get childModules => _childModules;
-
-  /// Internals
   HierarchyActions _actions;
+  List<Module> _childModules = [];
 
-  HierarchyStore(HierarchyActions this._actions) {
+  HierarchyStore(this._actions) {
     triggerOnAction(_actions.addChildModule, _addChildModule);
     triggerOnAction(_actions.removeChildModule, _removeChildModule);
   }
 
-  _addChildModule(Module newModule) {
+  List<Module> get childModules => _childModules;
+
+  void _addChildModule(Module newModule) {
     _childModules.add(newModule);
   }
 
-  _removeChildModule(Module oldModule) {
+  void _removeChildModule(Module oldModule) {
     // do we need to reject the unload?
     ShouldUnloadResult canUnload = oldModule.shouldUnload();
     if (!canUnload.shouldUnload) {
@@ -114,12 +119,14 @@ class HierarchyStore extends Store {
   }
 }
 
-var HierarchyComponent =
+// ignore: non_constant_identifier_names
+Object HierarchyComponent =
     react.registerComponent(() => new _HierarchyComponent());
 
 class _HierarchyComponent
     extends FluxComponent<HierarchyActions, HierarchyStore> {
-  render() {
+  @override
+  Object render() {
     return react.div(
         {
           'style': {

--- a/example/panel/modules/lifecycle_echo_module.dart
+++ b/example/panel/modules/lifecycle_echo_module.dart
@@ -12,38 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library w_module.example.panel.modules.lifecycleEcho_module;
+library w_module.example.panel.modules.lifecycle_echo_module;
 
 import 'dart:async';
 
-import 'package:w_module/w_module.dart';
+import 'package:meta/meta.dart' show protected;
 import 'package:react/react.dart' as react;
+import 'package:w_module/w_module.dart';
 
 class LifecycleEchoModule extends Module {
+  @override
   final String name = 'LifecycleEchoModule';
 
   LifecycleEchoComponents _components;
-  LifecycleEchoComponents get components => _components;
 
   LifecycleEchoModule() {
     // load / unload state streams
     willLoad.listen((_) {
-      print('${name}: willLoad');
+      print('$name: willLoad');
     });
     didLoad.listen((_) {
-      print('${name}: didLoad');
+      print('$name: didLoad');
     });
     willUnload.listen((_) {
-      print('${name}: willUnload');
+      print('$name: willUnload');
     });
     didUnload.listen((_) {
-      print('${name}: didUnload');
+      print('$name: didUnload');
     });
     didLoadChildModule.listen((_) {
-      print('${name}: didLoadChildModule');
+      print('$name: didLoadChildModule');
     });
     _components = new LifecycleEchoComponents();
   }
+
+  @override
+  LifecycleEchoComponents get components => _components;
 
   //--------------------------------------------------------
   // Methods that can be optionally implemented by subclasses
@@ -51,25 +55,32 @@ class LifecycleEchoModule extends Module {
   // lifecycle
   //--------------------------------------------------------
 
-  Future onLoad() async {
-    print('${name}: onLoad');
-    loadChildModule(new LifecycleEchoChildModule());
+  @override
+  @protected
+  Future<Null> onLoad() async {
+    print('$name: onLoad');
+    await loadChildModule(new LifecycleEchoChildModule());
     await new Future.delayed(new Duration(seconds: 1));
   }
 
+  @override
+  @protected
   ShouldUnloadResult onShouldUnload() {
-    print('${name}: onShouldUnload');
+    print('$name: onShouldUnload');
     return new ShouldUnloadResult();
   }
 
-  Future onUnload() async {
-    print('${name}: onUnload');
+  @override
+  @protected
+  Future<Null> onUnload() async {
+    print('$name: onUnload');
     await new Future.delayed(new Duration(seconds: 1));
   }
 }
 
 class LifecycleEchoComponents implements ModuleComponents {
-  content() => react.div({
+  @override
+  Object content() => react.div({
         'style': {
           'padding': '50px',
           'backgroundColor': 'lightGray',

--- a/example/panel/modules/reject_module.dart
+++ b/example/panel/modules/reject_module.dart
@@ -14,18 +14,19 @@
 
 library w_module.example.panel.modules.reject_module;
 
-import 'package:w_module/w_module.dart';
-import 'package:w_flux/w_flux.dart';
+import 'package:meta/meta.dart' show protected;
 import 'package:react/react.dart' as react;
+import 'package:w_flux/w_flux.dart';
+import 'package:w_module/w_module.dart';
 
 class RejectModule extends Module {
+  @override
   final String name = 'RejectModule';
 
   RejectActions _actions;
   RejectStore _stores;
 
   RejectComponents _components;
-  RejectComponents get components => _components;
 
   RejectModule() {
     _actions = new RejectActions();
@@ -33,11 +34,16 @@ class RejectModule extends Module {
     _components = new RejectComponents(_actions, _stores);
   }
 
+  @override
+  RejectComponents get components => _components;
+
+  @override
+  @protected
   ShouldUnloadResult onShouldUnload() {
     if (_stores.shouldUnload) {
       return new ShouldUnloadResult();
     }
-    return new ShouldUnloadResult(false, '${name} won\'t let you leave!');
+    return new ShouldUnloadResult(false, '$name won\'t let you leave!');
   }
 }
 
@@ -47,7 +53,8 @@ class RejectComponents implements ModuleComponents {
 
   RejectComponents(this._actions, this._stores);
 
-  content() => RejectComponent({'actions': _actions, 'store': _stores});
+  @override
+  Object content() => RejectComponent({'actions': _actions, 'store': _stores});
 }
 
 class RejectActions {
@@ -57,24 +64,27 @@ class RejectActions {
 class RejectStore extends Store {
   /// Public data
   bool _shouldUnload = true;
-  bool get shouldUnload => _shouldUnload;
 
   /// Internals
   RejectActions _actions;
 
-  RejectStore(RejectActions this._actions) {
+  RejectStore(this._actions) {
     triggerOnAction(_actions.toggleShouldUnload, _toggleShouldUnload);
   }
 
-  _toggleShouldUnload(_) {
+  bool get shouldUnload => _shouldUnload;
+
+  void _toggleShouldUnload(_) {
     _shouldUnload = !_shouldUnload;
   }
 }
 
-var RejectComponent = react.registerComponent(() => new _RejectComponent());
+// ignore: non_constant_identifier_names
+Object RejectComponent = react.registerComponent(() => new _RejectComponent());
 
 class _RejectComponent extends FluxComponent<RejectActions, RejectStore> {
-  render() {
+  @override
+  Object render() {
     return react.div({
       'style': {'padding': '50px', 'backgroundColor': 'green', 'color': 'white'}
     }, [

--- a/example/panel/panel_app.dart
+++ b/example/panel/panel_app.dart
@@ -14,17 +14,18 @@
 
 library w_module.example.panel;
 
+import 'dart:async';
 import 'dart:html';
 import 'dart:js' as js;
 
 import 'package:browser_detect/browser_detect.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart' as react_client;
-import 'package:w_module/w_module.dart';
+import 'package:w_module/w_module.dart' hide Event;
 
 import 'modules/panel_module.dart';
 
-main() async {
+Future<Null> main() async {
   Element container = querySelector('#panel-container');
   react_client.setClientConfiguration();
 
@@ -33,17 +34,20 @@ main() async {
   await panelModule.load();
 
   // block browser tab / window close if necessary
-  window.onBeforeUnload.listen((BeforeUnloadEvent event) {
+  window.onBeforeUnload.listen((Event event) {
+    if (event is! BeforeUnloadEvent) return;
+    BeforeUnloadEvent beforeUnloadEvent = event;
+
     // can the app be unloaded?
     ShouldUnloadResult res = panelModule.shouldUnload();
     if (!res.shouldUnload) {
       // return the supplied error message to block close
-      event.returnValue = res.messagesAsString();
+      beforeUnloadEvent.returnValue = res.messagesAsString();
     } else if (browser.isIe) {
       // IE interprets a null string as a response and displays an alert to
       // the user. Use the `undefined` value of the JS context instead.
       // https://github.com/dart-lang/sdk/issues/22589
-      event.returnValue = js.context['undefined'];
+      beforeUnloadEvent.returnValue = js.context['undefined'];
     }
   });
 

--- a/example/random_color/random_color.dart
+++ b/example/random_color/random_color.dart
@@ -14,6 +14,7 @@
 
 library w_module.example.random_color;
 
+import 'dart:async';
 import 'dart:html' as html;
 import 'dart:math';
 
@@ -23,7 +24,7 @@ import 'package:react/react_client.dart' as react_client;
 import 'package:w_flux/w_flux.dart';
 import 'package:w_module/w_module.dart';
 
-main() async {
+Future<Null> main() async {
   // instantiate the module and wait for it to load
   RandomColorModule randomColorModule = new RandomColorModule();
   await randomColorModule.load();
@@ -58,19 +59,14 @@ main() async {
 DispatchKey randomColorModuleDispatchKey = new DispatchKey('randomColor');
 
 class RandomColorModule extends Module {
+  @override
   final String name = 'RandomColorModule';
 
   RandomColorActions _actions;
-  RandomColorStore _stores;
-
   RandomColorApi _api;
-  RandomColorApi get api => _api;
-
-  RandomColorEvents _events;
-  RandomColorEvents get events => _events;
-
   RandomColorComponents _components;
-  RandomColorComponents get components => _components;
+  RandomColorEvents _events;
+  RandomColorStore _stores;
 
   RandomColorModule() {
     _actions = new RandomColorActions();
@@ -80,6 +76,15 @@ class RandomColorModule extends Module {
     _components = new RandomColorComponents(_actions, _stores);
     _api = new RandomColorApi(_actions, _stores);
   }
+
+  @override
+  RandomColorApi get api => _api;
+
+  @override
+  RandomColorComponents get components => _components;
+
+  @override
+  RandomColorEvents get events => _events;
 }
 
 class RandomColorApi {
@@ -88,11 +93,11 @@ class RandomColorApi {
 
   RandomColorApi(this._actions, this._stores);
 
-  setBackgroundColor(String newColor) {
+  void setBackgroundColor(String newColor) {
     _actions.setBackgroundColor(newColor);
   }
 
-  changeBackgroundColor() {
+  void changeBackgroundColor() {
     _actions.changeBackgroundColor();
   }
 
@@ -109,7 +114,9 @@ class RandomColorComponents implements ModuleComponents {
 
   RandomColorComponents(this._actions, this._stores);
 
-  content() => RandomColorComponent({'actions': _actions, 'store': _stores});
+  @override
+  Object content() =>
+      RandomColorComponent({'actions': _actions, 'store': _stores});
 }
 
 class RandomColorActions {
@@ -120,7 +127,6 @@ class RandomColorActions {
 class RandomColorStore extends Store {
   /// Public data
   String _backgroundColor = 'gray';
-  String get backgroundColor => _backgroundColor;
 
   RandomColorEvents _events;
   DispatchKey _dispatchKey;
@@ -128,13 +134,14 @@ class RandomColorStore extends Store {
   /// Internals
   RandomColorActions _actions;
 
-  RandomColorStore(RandomColorActions this._actions,
-      RandomColorEvents this._events, DispatchKey this._dispatchKey) {
+  RandomColorStore(this._actions, this._events, this._dispatchKey) {
     _actions.changeBackgroundColor.listen(_changeBackgroundColor);
     _actions.setBackgroundColor.listen(_setBackgroundColor);
   }
 
-  _changeBackgroundColor(_) {
+  String get backgroundColor => _backgroundColor;
+
+  void _changeBackgroundColor(_) {
     // generate a random hex color string
     _backgroundColor =
         '#' + (new Random().nextDouble() * 16777215).floor().toRadixString(16);
@@ -142,7 +149,7 @@ class RandomColorStore extends Store {
     trigger();
   }
 
-  _setBackgroundColor(String newColor) {
+  void _setBackgroundColor(String newColor) {
     // generate a random hex color string
     _backgroundColor = newColor;
     _events.colorChanged(_backgroundColor, _dispatchKey);
@@ -150,12 +157,14 @@ class RandomColorStore extends Store {
   }
 }
 
-var RandomColorComponent =
+// ignore: non_constant_identifier_names
+Object RandomColorComponent =
     react.registerComponent(() => new _RandomColorComponent());
 
 class _RandomColorComponent
     extends FluxComponent<RandomColorActions, RandomColorStore> {
-  render() {
+  @override
+  Object render() {
     return react.div({
       'style': {
         'padding': '50px',

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -35,11 +35,12 @@ class Event<T> extends Stream<T> {
 
   /// Create an Event and associate it with [key].
   Event(DispatchKey key) : _key = key {
-    var c = new StreamController.broadcast();
+    var c = new StreamController<T>.broadcast();
     _sink = c.sink;
     _stream = c.stream;
   }
 
+  @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
     return _stream.listen(onData,
@@ -63,5 +64,5 @@ class Event<T> extends Stream<T> {
 /// One key can be used for multiple events.
 class DispatchKey {
   String name;
-  DispatchKey([String this.name]);
+  DispatchKey([this.name]);
 }

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -36,12 +36,12 @@ abstract class Module extends LifecycleModule {
   /// be overridden to provide a class defined specifically for the module.
   ///
   /// If using with w_flux internals, module mutation methods should usually
-  /// dispatch existing [actions] available within the module.  This ensures
+  /// dispatch existing actions available within the module.  This ensures
   /// that the internal unidirectional data flow is maintained, regardless of
   /// the source of the mutation (e.g. external api or internal UI).  Likewise,
   /// module methods that expose internal state should usually use existing
   /// getter methods available on stores within the module.
-  get api => null;
+  Object get api => null;
 
   /// The [components] object should contain all react-dart compatible UI
   /// component factory methods that a consumer can use to render module data.
@@ -72,12 +72,12 @@ abstract class Module extends LifecycleModule {
   /// immediate response to actions.  This ensures that the internal
   /// unidirectional data flow is maintained and external [events] represent
   /// confirmed internal state changes.
-  get events => null;
+  Object get events => null;
 }
 
-/// Standard [Module] [components] class. If a module implements a custom
-/// [components] class, it should extend [ModuleComponents].
+/// Standard [Module.components] class. If a module implements a custom class
+/// for its components, it should extend [ModuleComponents].
 abstract class ModuleComponents {
   /// The default UI component
-  content() {}
+  Object content() => null;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ authors:
 homepage: https://github.com/Workiva/w_module
 dependencies:
   logging: "^0.11.0"
+  meta: "^1.0.0"
 dev_dependencies:
   browser: "^0.10.0+2"
   browser_detect: "^1.0.3"

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -18,12 +18,14 @@ library w_module.test.lifecycle_module_test;
 import 'dart:async';
 
 import 'package:logging/logging.dart';
-import 'package:w_module/w_module.dart';
+import 'package:meta/meta.dart' show protected;
 import 'package:test/test.dart';
+import 'package:w_module/w_module.dart';
 
 const String shouldUnloadError = 'Mock shouldUnload false message';
 
 class TestLifecycleModule extends LifecycleModule {
+  @override
   final String name = 'TestLifecycleModule';
 
   // mock data to be used for test validation
@@ -76,27 +78,45 @@ class TestLifecycleModule extends LifecycleModule {
     });
   }
 
-  Future onWillLoadChildModule(LifecycleModule module) async {
+  // Overriding without re-applying the @protected annotation allows us to call
+  // loadChildModule in our tests below.
+  @override
+  Future<Null> loadChildModule(LifecycleModule newModule) =>
+      super.loadChildModule(newModule);
+
+  @override
+  @protected
+  Future<Null> onWillLoadChildModule(LifecycleModule module) async {
     eventList.add('onWillLoadChildModule');
   }
 
-  Future onDidLoadChildModule(LifecycleModule module) async {
+  @override
+  @protected
+  Future<Null> onDidLoadChildModule(LifecycleModule module) async {
     eventList.add('onDidLoadChildModule');
   }
 
-  Future onWillUnloadChildModule(LifecycleModule module) async {
+  @override
+  @protected
+  Future<Null> onWillUnloadChildModule(LifecycleModule module) async {
     eventList.add('onWillUnloadChildModule');
   }
 
-  Future onDidUnloadChildModule(LifecycleModule module) async {
+  @override
+  @protected
+  Future<Null> onDidUnloadChildModule(LifecycleModule module) async {
     eventList.add('onDidUnloadChildModule');
   }
 
-  Future onLoad() async {
+  @override
+  @protected
+  Future<Null> onLoad() async {
     await new Future.delayed(new Duration(milliseconds: 1));
     eventList.add('onLoad');
   }
 
+  @override
+  @protected
   ShouldUnloadResult onShouldUnload() {
     eventList.add('onShouldUnload');
     if (mockShouldUnload) {
@@ -106,17 +126,23 @@ class TestLifecycleModule extends LifecycleModule {
     }
   }
 
-  Future onUnload() async {
+  @override
+  @protected
+  Future<Null> onUnload() async {
     await new Future.delayed(new Duration(milliseconds: 1));
     eventList.add('onUnload');
   }
 
-  Future onSuspend() async {
+  @override
+  @protected
+  Future<Null> onSuspend() async {
     await new Future.delayed(new Duration(milliseconds: 1));
     eventList.add('onSuspend');
   }
 
-  Future onResume() async {
+  @override
+  @protected
+  Future<Null> onResume() async {
     await new Future.delayed(new Duration(milliseconds: 1));
     eventList.add('onResume');
   }

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -14,9 +14,11 @@
 
 library tool.dev;
 
+import 'dart:async';
+
 import 'package:dart_dev/dart_dev.dart' show dev, config;
 
-main(List<String> args) async {
+Future<Null> main(List<String> args) async {
   // https://github.com/Workiva/dart_dev
 
   List<String> directories = ['example/', 'lib/', 'test/', 'tool/'];


### PR DESCRIPTION
## Improvement
The `meta` package has a `@protected` annotation that we can leverage to mark certain public class methods as callable only by instances of said class. This will be useful for our `onEvent()` methods that are expected to be overridden by subclasses of `Module` in order to respond to a particular event since they should only be called by the internal module logic and not by consumers of the module.

## Changes
- Add `@protected` annotation to:
  - `loadChildModule()`
  - `onWillLoadChildModule()`
  - `onDidLoadChildModule()`
  - `onWillUnloadChildModule()`
  - `onDidUnloadChildModule()`
  - `onLoad()`
  - `onShouldUnload()`
  - `onUnload()`

> Caveat: When a subclass overrides a `@protected` method, they too will have to add the `@protected` annotation to their override in order for the analyzer to enforce the protected behavior on usages of that class method.
>
> However, this actually has a hidden benefit - you can choose to subclass and override a protected method and intentionally omit the `@protected` annotation to sidestep that rule. This is useful for testing (in fact I used this to update an existing test in this PR).

- **Bonus:** enable strong-mode analysis and fix warnings/hints.
- **Bonus:** enable linter and most lint rules and fix lints.
- **Bonus:** deprecate the `LifecycleModule.name` setter. The purpose of the `name` field was to allow modules a way to identify themselves, but there's no reason that value should ever change or be mutable to consumers of a module.

## Breaking Changes
- Changing the signature of several methods from `Future` to `Future<Null>` is technically a stricter typing since `Future` implies `Future<dynamic>`. This could produce an analyzer error for consumers that extend and override these methods, but I _think_ that may only be if strong mode is enabled.

## Testing
- [ ] CI passes

## Code Review
fya: @trentgrover-wf @maxwellpeterson-wf @dustinlessard-wf @jayudey-wf @sebastianmalysa-wf 

fyi (the `@protected` usage may interest you): @todbachman-wf @georgelesica-wf @aaronstgeorge-wf @bencampbell-wf  