### PR TITLE
MOBILE-2277: Implement serializable w_module

### DIFF
--- a/lib/serializable_module.dart
+++ b/lib/serializable_module.dart
@@ -1,0 +1,17 @@
+// Copyright 2016 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library serializable_module;
+
+export 'package:w_module/src/serializable.dart';

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -14,7 +14,7 @@
 
 library w_module.src.module;
 
-import 'lifecycle_module.dart';
+import 'package:w_module/src/lifecycle_module.dart';
 
 /// A [Module] encapsulates a well-scoped logical unit of functionality and
 /// exposes a discrete public interface for consumers.  It extends

--- a/lib/src/serializable.dart
+++ b/lib/src/serializable.dart
@@ -202,7 +202,7 @@ class SerializableBus {
             ClassMirror paramClassMirror =
                 reflectClass(param.type.reflectedType);
 
-            // Paramter type must implement fromJson model that takes a Map
+            // Paramter type must implement fromJson name constructor that takes a Map
             try {
               var instance = paramClassMirror
                   .newInstance(new Symbol('fromJson'), [data[i]]).reflectee;

--- a/lib/src/serializable.dart
+++ b/lib/src/serializable.dart
@@ -225,6 +225,11 @@ class SerializableBus {
 
     event['data'] = data;
 
-    _bridge?.broadcastSerializedEvent(event);
+    if (_bridge != null) {
+      _bridge.broadcastSerializedEvent(event);
+    } else {
+      _logger.warning('Unable to send $event for ${module.serializableKey}, no bridge defined');
+    }
+
   }
 }

--- a/lib/src/serializable.dart
+++ b/lib/src/serializable.dart
@@ -197,22 +197,25 @@ class SerializableBus {
 
         // If the type data being passed to this param is not equal to the expected type
         // try to serialize it into an Dart class
-        if (param.type.reflectedType != data[i].runtimeType && data[i] is Map) {
-          ClassMirror paramClassMirror = reflectClass(param.type.reflectedType);
+        if (param.type.reflectedType != data[i].runtimeType) {
+          if (data[i] is Map) {
+            ClassMirror paramClassMirror =
+                reflectClass(param.type.reflectedType);
 
-          // Paramter type must implement fromJson model that takes a Map
-          try {
-            var instance = paramClassMirror
-                .newInstance(new Symbol('fromJson'), [data[i]]).reflectee;
-            data[i] = instance;
-          } on NoSuchMethodError {
-            _logger.warning(
-                '${paramClassMirror.simpleName.toString()} does not implement fromJson named constructor');
+            // Paramter type must implement fromJson model that takes a Map
+            try {
+              var instance = paramClassMirror
+                  .newInstance(new Symbol('fromJson'), [data[i]]).reflectee;
+              data[i] = instance;
+            } on NoSuchMethodError {
+              _logger.warning(
+                  '${paramClassMirror.simpleName.toString()} does not implement fromJson named constructor');
+              return;
+            }
+          } else {
+            _logger.warning('Incompatiable type for deserialization');
             return;
           }
-        } else {
-          _logger.warning('Incompatiable type for deserialization');
-          return;
         }
       }
 

--- a/lib/src/serializable.dart
+++ b/lib/src/serializable.dart
@@ -228,8 +228,8 @@ class SerializableBus {
     if (_bridge != null) {
       _bridge.broadcastSerializedEvent(event);
     } else {
-      _logger.warning('Unable to send $event for ${module.serializableKey}, no bridge defined');
+      _logger.warning(
+          'Unable to send $event for ${module.serializableKey}, no bridge defined');
     }
-
   }
 }

--- a/lib/src/serializable.dart
+++ b/lib/src/serializable.dart
@@ -1,0 +1,238 @@
+// Copyright 2016 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library serializable_module.src.serializable;
+
+@MirrorsUsed(metaTargets: 'serializable_module.src.serializable.Reflectable')
+import 'dart:mirrors';
+import 'dart:async';
+import 'dart:html' show window, CustomEvent;
+import 'dart:js' show JsObject, context;
+
+import 'package:logging/logging.dart';
+import 'package:w_common/w_common.dart' show JsonSerializable;
+
+import 'event.dart';
+import 'module.dart';
+
+// Any classes / methods that are going to be reflected must annotate with this
+class Reflectable {
+  const Reflectable();
+}
+
+abstract class Bridge<T> {
+  StreamController<Map> _eventController;
+
+  Bridge() {
+    _eventController = new StreamController<Map>.broadcast();
+  }
+
+  void broadcast(Map dataToSend);
+  void handleEvent(T apiCall);
+
+  Stream<Map> get eventReceived => _eventController.stream;
+}
+
+// This class is used to communicate across a WKWebView in an iOS app
+class WKWebViewBridge extends Bridge<CustomEvent> {
+  WKWebViewBridge() {
+    window.on['bridge'].listen(handleEvent);
+  }
+
+  @override
+  void broadcast(Map dataToSend) {
+    wkBridge?.callMethod('postMessage', [new JsObject.jsify(dataToSend)]);
+  }
+
+  @override
+  void handleEvent(CustomEvent apiCall) {
+    _eventController.add(apiCall.detail);
+  }
+
+  JsObject get wkBridge {
+    if (context['webkit'] != null) {
+      return context['webkit']['messageHandlers']['bridge'];
+    } else {
+      return null;
+    }
+  }
+}
+
+class SerializableEvent<T> extends Event<T> {
+  SerializableEvent(this._eventKey, DispatchKey dispatchKey)
+      : super(dispatchKey);
+
+  String _eventKey;
+  String get eventKey => _eventKey;
+}
+
+abstract class SerializableEvents {
+  List<SerializableEvent> get allEvents => [];
+}
+
+abstract class SerializableModule extends Module {
+  SerializableModule() {
+    _registerWithSerializableBus();
+  }
+
+  void _registerWithSerializableBus() {
+    SerializableBus.sharedBus.registerModule(this);
+  }
+
+  @override
+  SerializableEvents get events => null;
+
+  String get serializableKey => null;
+}
+
+class SerializableBus {
+  SerializableBus() {
+    _registeredModules = new Map<String, SerializableModule>();
+    _logger = new Logger('Serializable Bus');
+  }
+
+  static final SerializableBus _singleton = new SerializableBus();
+  static SerializableBus get sharedBus => _singleton;
+
+  Bridge _bridge;
+  Logger _logger;
+  Map<String, SerializableModule> _registeredModules;
+
+  void reset() {
+    _registeredModules = new Map<String, SerializableModule>();
+    _bridge = null;
+  }
+
+  void registerModule(SerializableModule module) {
+    if (module.serializableKey != null) {
+      _registerForLifecylceEvents(module);
+      _registeredModules[module.serializableKey] = module;
+    } else {
+      _logger.warning('Unable to serialize module without serializableKey');
+    }
+  }
+
+  void deregisterModule(SerializableModule module) {
+    _registeredModules.remove(module.serializableKey);
+  }
+
+  void _registerForAllEvents(SerializableModule module) {
+    if (module.events != null) {
+      for (var event in module.events.allEvents) {
+        if (event is SerializableEvent) {
+          event
+              .listen((payload) => _sendEvent(module, event.eventKey, payload));
+        }
+      }
+    } else {
+      _logger
+          .warning('Events not defined for ${module.serializableKey} module');
+    }
+  }
+
+  void _registerForLifecylceEvents(SerializableModule module) {
+    module.willLoad.listen((_) {
+      _registerForAllEvents(module);
+      _sendEvent(module, 'willLoad', null);
+    });
+    module.didLoad.listen((_) => _sendEvent(module, 'didLoad', null));
+    module.willUnload.listen((_) => _sendEvent(module, 'willUnload', null));
+    module.didUnload.listen((_) {
+      _sendEvent(module, 'didUnload', null);
+      deregisterModule(module);
+    });
+  }
+
+  void _sendEvent(SerializableModule module, String eventKey, Object data) {
+    Map dataToSend = new Map();
+    dataToSend['module'] = module.serializableKey;
+    dataToSend['event'] = eventKey;
+
+    if (data is JsonSerializable) {
+      data = (data as JsonSerializable).toJson();
+    }
+
+    dataToSend['data'] = data;
+
+    _bridge?.broadcast(dataToSend);
+  }
+
+  void _handleApiCall(Map apiCall) {
+    String module = apiCall['module'];
+    String method = apiCall['method'];
+    Object data = apiCall["data"];
+
+    SerializableModule targetModule = _registeredModules[module];
+
+    _deserializeAndCall(targetModule, method, data);
+  }
+
+  void _deserializeAndCall(
+      SerializableModule module, String method, List data) {
+    InstanceMirror apiMirror = reflect(module.api);
+    ClassMirror classMirror = apiMirror.type;
+    MethodMirror apiMethodMirror = classMirror.declarations[new Symbol(method)];
+
+    if (apiMethodMirror == null) {
+      _logger.warning(
+          'Method $method does not exist on ${module.serializableKey}\' module\'s API');
+      return;
+    }
+    // Check here that the position args in data match the expected params of the method being called
+    if (data is List && apiMethodMirror.parameters.length == data.length) {
+      for (var i = 0; i < apiMethodMirror.parameters.length; i++) {
+        var param = apiMethodMirror.parameters[i];
+
+        // If the type data being passed to this param is not equal to the expected type
+        // try to serialize it into an Dart class
+        if (param.type.reflectedType != data[i].runtimeType) {
+          ClassMirror paramClassMirror = reflectClass(param.type.reflectedType);
+
+          ClassMirror superClassMirror = paramClassMirror.superclass;
+          while (
+              paramClassMirror.superclass.reflectedType != JsonSerializable &&
+                  paramClassMirror.superclass != null) {
+            superClassMirror = superClassMirror.superclass;
+          }
+
+          // Ensure that super class of the expected param type is JsonSerializable
+          // This way we know we can deserialize the class from a Map
+          if (superClassMirror != null && data[i] is Map) {
+            // Create a new instance of the expected param type and pull the instance off the mirror
+            var instance = paramClassMirror
+                .newInstance(new Symbol('fromJson'), [data[i]]).reflectee;
+            data[i] = instance;
+          } else {
+            _logger.warning('Unable to deserialize map to Dart Object');
+            return;
+          }
+        }
+      }
+
+      if (apiMirror != null) {
+        apiMirror.invoke(new Symbol(method), data);
+      }
+    } else {
+      _logger.warning(
+          'Unable to call api method $method in $module w_module, mismatched params');
+    }
+  }
+
+  Map<String, SerializableModule> get registeredModules => _registeredModules;
+
+  set bridge(Bridge bridge) {
+    _bridge = bridge;
+    _bridge.eventReceived.listen(_handleApiCall);
+  }
+}

--- a/lib/src/serializable.dart
+++ b/lib/src/serializable.dart
@@ -36,8 +36,7 @@ abstract class Bridge<T> extends Object with Disposable {
   void broadcastSerializedEvent(Map event);
   void handleSerializedApiCall(T apiCall);
 
-  @override
-  void manageStreamSubscription(StreamSubscription subscription) {
+  void _manageStreamSubscription(StreamSubscription subscription) {
     super.manageStreamSubscription(subscription);
   }
 }
@@ -85,13 +84,15 @@ class SerializableBus {
 
   Bridge get bridge => _bridge;
   set bridge(Bridge bridge) {
-    if (_bridge != null) {
-      _bridge.dispose();
-    }
+    _bridge?.dispose();
 
-    _bridge = bridge;
-    _bridge.manageStreamSubscription(
-        bridge.apiCallReceived.listen(_handleApiCall));
+    if (bridge != null) {
+      _bridge = bridge;
+      _bridge?._manageStreamSubscription(
+          bridge.apiCallReceived.listen(_handleApiCall));
+    } else {
+      _logger.warning('Attempt to set bridge to null');
+    }
   }
 
   Map<String, SerializableModule> get registeredModules =>

--- a/lib/src/serializable.dart
+++ b/lib/src/serializable.dart
@@ -85,6 +85,10 @@ class SerializableBus {
 
   Bridge get bridge => _bridge;
   set bridge(Bridge bridge) {
+    if (_bridge != null) {
+      _bridge.dispose();
+    }
+
     _bridge = bridge;
     _bridge.manageStreamSubscription(
         bridge.apiCallReceived.listen(_handleApiCall));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ homepage: https://github.com/Workiva/w_module
 dependencies:
   logging: "^0.11.0"
   meta: "^1.0.0"
-  w_common: "^0.2.0"
+  w_common: "^1.0.0"
 
 dev_dependencies:
   browser: "^0.10.0+2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,14 @@ homepage: https://github.com/Workiva/w_module
 dependencies:
   logging: "^0.11.0"
   meta: "^1.0.0"
+  w_common: "^0.0.1"
+
+dependency_overrides:
+  w_common:
+    git:
+      url: git@github.com:brianblanchard-wf/w_common.git
+      ref: MOBILE-2292
+
 dev_dependencies:
   browser: "^0.10.0+2"
   browser_detect: "^1.0.3"
@@ -19,7 +27,7 @@ dev_dependencies:
   dart_dev: "^1.0.0"
   dart_style: "^0.2.1"
   dartdoc: "^0.8.0"
-  mockito: "^0.10.0"
+  mockito: "^1.0.1"
   react: ">=0.5.0 <0.8.0"
   test: "^0.12.0"
   w_flux: "^1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,13 +12,7 @@ homepage: https://github.com/Workiva/w_module
 dependencies:
   logging: "^0.11.0"
   meta: "^1.0.0"
-  w_common: "^0.0.1"
-
-dependency_overrides:
-  w_common:
-    git:
-      url: git@github.com:brianblanchard-wf/w_common.git
-      ref: MOBILE-2292
+  w_common: "^0.2.0"
 
 dev_dependencies:
   browser: "^0.10.0+2"

--- a/test/serializable_test.dart
+++ b/test/serializable_test.dart
@@ -293,7 +293,8 @@ void main() {
       expect(api.removeCalled, isTrue);
     });
 
-    test('should not call api method if paramater lengths are mismatched', () async {
+    test('should not call api method if paramater lengths are mismatched',
+        () async {
       Completer completer = new Completer();
       Map<String, dynamic> apiCall = {
         'module': serializableKey,
@@ -312,7 +313,8 @@ void main() {
       expect(api.removeCalled, isFalse);
     });
 
-    test('should not call api method if paramater types are mismatched', () async {
+    test('should not call api method if paramater types are mismatched',
+        () async {
       Completer completer = new Completer();
       Map<String, dynamic> apiCall = {
         'module': serializableKey,

--- a/test/serializable_test.dart
+++ b/test/serializable_test.dart
@@ -164,7 +164,7 @@ void main() {
       when(module.willUnload).thenReturn(willUnloadController.stream);
       when(module.didUnload).thenReturn(didUnloadController.stream);
 
-      when(bridge.eventReceived).thenReturn(bridgeEventController.stream);
+      when(bridge.apiCallReceived).thenReturn(bridgeEventController.stream);
 
       bus.registerModule(module);
       bus.bridge = bridge;
@@ -177,7 +177,7 @@ void main() {
 
     test('should properly register modules and register for lifecycle events',
         () async {
-      expect(bus.registeredModules[serializableKey], module);
+      expect(bus.moduleRegistrations[serializableKey].module, module);
       verify(module.willLoad);
       verify(module.didLoad);
       verify(module.willUnload);
@@ -204,7 +204,7 @@ void main() {
       event.call(null, dispatchKey);
       await eventCompleter.future;
 
-      verify(bridge.broadcast(expectedEvent));
+      verify(bridge.broadcastSerializedEvent(expectedEvent));
     });
 
     test('should fire the module willLoad event', () async {
@@ -217,7 +217,7 @@ void main() {
       willLoadController.add(null);
       await lifecycleCompleter.future;
 
-      verify(bridge.broadcast(expectedEvent));
+      verify(bridge.broadcastSerializedEvent(expectedEvent));
     });
 
     test('should fire the module didLoad event', () async {
@@ -230,7 +230,7 @@ void main() {
       didLoadController.add(null);
       await lifecycleCompleter.future;
 
-      verify(bridge.broadcast(expectedEvent));
+      verify(bridge.broadcastSerializedEvent(expectedEvent));
     });
 
     test('should fire the module willUnload event', () async {
@@ -243,7 +243,7 @@ void main() {
       willUnloadController.add(null);
       await lifecycleCompleter.future;
 
-      verify(bridge.broadcast(expectedEvent));
+      verify(bridge.broadcastSerializedEvent(expectedEvent));
     });
 
     test('should fire the module didUnload event', () async {
@@ -256,7 +256,7 @@ void main() {
       didUnloadController.add(null);
       await lifecycleCompleter.future;
 
-      verify(bridge.broadcast(expectedEvent));
+      verify(bridge.broadcastSerializedEvent(expectedEvent));
     });
 
     test('should call correct api method', () async {

--- a/test/serializable_test.dart
+++ b/test/serializable_test.dart
@@ -172,7 +172,7 @@ void main() {
 
     test('should provide a singleton', () async {
       expect(SerializableBus.sharedBus, isNotNull);
-      expect(SerializableBus.sharedBus is SerializableBus, isTrue);
+      expect(SerializableBus.sharedBus, new isInstanceOf<SerializableBus>());
     });
 
     test('should properly register modules and register for lifecycle events',

--- a/test/serializable_test.dart
+++ b/test/serializable_test.dart
@@ -166,6 +166,7 @@ void main() {
 
       when(bridge.apiCallReceived).thenReturn(bridgeEventController.stream);
 
+      bus.reset();
       bus.registerModule(module);
       bus.bridge = bridge;
     });
@@ -303,23 +304,6 @@ void main() {
           {'name': 'Rob Stark'},
           {'one': 'tomany'}
         ]
-      };
-
-      bridgeEventController.stream.listen((_) => completer.complete());
-      bridgeEventController.add(apiCall);
-
-      await completer.future;
-
-      expect(api.removeCalled, isFalse);
-    });
-
-    test('should not call api method if paramater types are mismatched',
-        () async {
-      Completer completer = new Completer();
-      Map<String, dynamic> apiCall = {
-        'module': serializableKey,
-        'method': 'remove',
-        'data': ['wrongType']
       };
 
       bridgeEventController.stream.listen((_) => completer.complete());

--- a/test/serializable_test.dart
+++ b/test/serializable_test.dart
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn('browser')
+@TestOn('vm || browser')
 library serializable_module.test.serializable_test;
 
 import 'dart:async';
 
 import 'package:w_module/serializable_module.dart';
-import 'package:w_common/w_common.dart';
+import 'package:w_common/json_serializable.dart' show JsonSerializable;
 import 'package:w_module/w_module.dart';
 import 'package:test/test.dart';
 import 'package:mockito/mockito.dart';
@@ -177,7 +177,7 @@ void main() {
 
     test('should properly register modules and register for lifecycle events',
         () async {
-      expect(bus.moduleRegistrations[serializableKey].module, module);
+      expect(bus.registeredModules[serializableKey], module);
       verify(module.willLoad);
       verify(module.didLoad);
       verify(module.willUnload);

--- a/test/serializable_test.dart
+++ b/test/serializable_test.dart
@@ -1,0 +1,331 @@
+// Copyright 2016 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('browser')
+library serializable_module.test.serializable_test;
+
+import 'dart:async';
+
+import 'package:w_module/serializable_module.dart';
+import 'package:w_common/w_common.dart';
+import 'package:w_module/w_module.dart';
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
+
+DispatchKey dispatchKey = new DispatchKey('serializable');
+
+class TestSerializableModule extends SerializableModule {}
+
+@Reflectable()
+class TestSerializable extends JsonSerializable {
+  String _name;
+  TestSerializable();
+  TestSerializable.fromJson(Map<String, dynamic> json) {
+    _name = json['name'];
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {'name': _name};
+  }
+}
+
+@Reflectable()
+class TestApi {
+  bool addCalled = false;
+  bool removeCalled = false;
+
+  void add() {
+    addCalled = true;
+  }
+
+  void remove(TestSerializable serializable) {
+    removeCalled = true;
+  }
+}
+
+class TestEvents extends Object with SerializableEvents {
+  final SerializableEvent testEvent =
+      new SerializableEvent('testEvent', dispatchKey);
+
+  @override
+  List<SerializableEvent> get allEvents => [testEvent];
+}
+
+class MockSerializableBus extends Mock implements SerializableBus {}
+
+class MockSerializableModule extends Mock implements SerializableModule {}
+
+class MockSerializableEvent extends Mock implements SerializableEvent {}
+
+class MockTestEvents extends Mock implements TestEvents {}
+
+class MockBridge extends Mock implements Bridge {}
+
+void main() {
+  group('SerializableModule', () {
+    SerializableModule module;
+
+    setUp(() {
+      module = new TestSerializableModule();
+    });
+
+    test('should return null for serializableKey by default', () async {
+      expect(module.serializableKey, isNull);
+    });
+
+    test('should return null for events by default', () async {
+      expect(module.events, isNull);
+    });
+  });
+
+  group('SerializeableEvent', () {
+    SerializableEvent event;
+    String eventKey = 'eventKey';
+
+    setUp(() {
+      event = new SerializableEvent(eventKey, dispatchKey);
+    });
+
+    test('should have an eventKey', () async {
+      expect(event.eventKey, eventKey);
+    });
+  });
+
+  group('SerializableEvents', () {
+    TestEvents events;
+
+    setUp(() {
+      events = new TestEvents();
+    });
+
+    test('should provide a list of all events', () async {
+      expect(events.allEvents, [events.testEvent]);
+    });
+  });
+
+  group('SerializableBus', () {
+    Completer lifecycleCompleter;
+    StreamController willLoadController;
+    StreamController didLoadController;
+    StreamController willUnloadController;
+    StreamController didUnloadController;
+    StreamController bridgeEventController;
+
+    SerializableBus bus;
+    SerializableEvent event;
+
+    var module;
+    var events;
+    var api;
+    var bridge;
+
+    String serializableKey = 'serializableKey';
+    String testEventKey = 'testEvent';
+
+    setUp(() {
+      lifecycleCompleter = new Completer();
+      bus = new SerializableBus();
+      module = new MockSerializableModule();
+      event = new SerializableEvent(testEventKey, dispatchKey);
+      events = new MockTestEvents();
+      api = new TestApi();
+      bridge = new MockBridge();
+
+      willLoadController = new StreamController.broadcast();
+      didLoadController = new StreamController.broadcast();
+      willUnloadController = new StreamController.broadcast();
+      didUnloadController = new StreamController.broadcast();
+      bridgeEventController = new StreamController.broadcast();
+
+      willLoadController.stream.listen((_) => lifecycleCompleter.complete());
+      didLoadController.stream.listen((_) => lifecycleCompleter.complete());
+      didUnloadController.stream.listen((_) => lifecycleCompleter.complete());
+      willUnloadController.stream.listen((_) => lifecycleCompleter.complete());
+
+      when(events.allEvents).thenReturn([event]);
+
+      when(module.api).thenReturn(api);
+      when(module.events).thenReturn(events);
+      when(module.serializableKey).thenReturn(serializableKey);
+      when(module.willLoad).thenReturn(willLoadController.stream);
+      when(module.didLoad).thenReturn(didLoadController.stream);
+      when(module.willUnload).thenReturn(willUnloadController.stream);
+      when(module.didUnload).thenReturn(didUnloadController.stream);
+
+      when(bridge.eventReceived).thenReturn(bridgeEventController.stream);
+
+      bus.registerModule(module);
+      bus.bridge = bridge;
+    });
+
+    test('should provide a singleton', () async {
+      expect(SerializableBus.sharedBus, isNotNull);
+      expect(SerializableBus.sharedBus is SerializableBus, isTrue);
+    });
+
+    test('should properly register modules and register for lifecycle events',
+        () async {
+      expect(bus.registeredModules[serializableKey], module);
+      verify(module.willLoad);
+      verify(module.didLoad);
+      verify(module.willUnload);
+      verify(module.didUnload);
+    });
+
+    test('should register for all module events', () async {
+      Map<String, dynamic> expectedEvent = {
+        'module': serializableKey,
+        'event': testEventKey,
+        'data': null
+      };
+
+      Completer eventCompleter = new Completer();
+
+      willLoadController.add(null);
+
+      await lifecycleCompleter.future;
+
+      event.listen((_) {
+        eventCompleter.complete();
+      });
+
+      event.call(null, dispatchKey);
+      await eventCompleter.future;
+
+      verify(bridge.broadcast(expectedEvent));
+    });
+
+    test('should fire the module willLoad event', () async {
+      Map<String, dynamic> expectedEvent = {
+        'module': serializableKey,
+        'event': 'willLoad',
+        'data': null
+      };
+
+      willLoadController.add(null);
+      await lifecycleCompleter.future;
+
+      verify(bridge.broadcast(expectedEvent));
+    });
+
+    test('should fire the module didLoad event', () async {
+      Map<String, dynamic> expectedEvent = {
+        'module': serializableKey,
+        'event': 'didLoad',
+        'data': null
+      };
+
+      didLoadController.add(null);
+      await lifecycleCompleter.future;
+
+      verify(bridge.broadcast(expectedEvent));
+    });
+
+    test('should fire the module willUnload event', () async {
+      Map<String, dynamic> expectedEvent = {
+        'module': serializableKey,
+        'event': 'willUnload',
+        'data': null
+      };
+
+      willUnloadController.add(null);
+      await lifecycleCompleter.future;
+
+      verify(bridge.broadcast(expectedEvent));
+    });
+
+    test('should fire the module didUnload event', () async {
+      Map<String, dynamic> expectedEvent = {
+        'module': serializableKey,
+        'event': 'didUnload',
+        'data': null
+      };
+
+      didUnloadController.add(null);
+      await lifecycleCompleter.future;
+
+      verify(bridge.broadcast(expectedEvent));
+    });
+
+    test('should call correct api method', () async {
+      Completer completer = new Completer();
+      Map<String, dynamic> apiCall = {
+        'module': serializableKey,
+        'method': 'add',
+        'data': []
+      };
+
+      bridgeEventController.stream.listen((_) => completer.complete());
+      bridgeEventController.add(apiCall);
+
+      await completer.future;
+
+      expect(api.addCalled, isTrue);
+    });
+
+    test('should correctly serialize data and call api method', () async {
+      Completer completer = new Completer();
+      Map<String, dynamic> apiCall = {
+        'module': serializableKey,
+        'method': 'remove',
+        'data': [
+          {'name': 'Rob Stark'}
+        ]
+      };
+
+      bridgeEventController.stream.listen((_) => completer.complete());
+      bridgeEventController.add(apiCall);
+
+      await completer.future;
+
+      expect(api.removeCalled, isTrue);
+    });
+
+    test('should not call api method if paramater lengths are mismatched', () async {
+      Completer completer = new Completer();
+      Map<String, dynamic> apiCall = {
+        'module': serializableKey,
+        'method': 'remove',
+        'data': [
+          {'name': 'Rob Stark'},
+          {'one': 'tomany'}
+        ]
+      };
+
+      bridgeEventController.stream.listen((_) => completer.complete());
+      bridgeEventController.add(apiCall);
+
+      await completer.future;
+
+      expect(api.removeCalled, isFalse);
+    });
+
+    test('should not call api method if paramater types are mismatched', () async {
+      Completer completer = new Completer();
+      Map<String, dynamic> apiCall = {
+        'module': serializableKey,
+        'method': 'remove',
+        'data': ['wrongType']
+      };
+
+      bridgeEventController.stream.listen((_) => completer.complete());
+      bridgeEventController.add(apiCall);
+
+      await completer.future;
+
+      expect(api.removeCalled, isFalse);
+    });
+  });
+}

--- a/test/serializable_test.dart
+++ b/test/serializable_test.dart
@@ -175,6 +175,17 @@ void main() {
       expect(SerializableBus.sharedBus, new isInstanceOf<SerializableBus>());
     });
 
+    test('should reset the bus', () async {
+      bus.reset();
+      expect(bus.registeredModules.keys.length, equals(0));
+      expect(bus.bridge, isNull);
+    });
+
+    test('should not allow a bridge to be set to null', () async {
+      bus.bridge = null;
+      expect(bus.bridge, isNotNull);
+    });
+
     test('should properly register modules and register for lifecycle events',
         () async {
       expect(bus.registeredModules[serializableKey], module);
@@ -253,10 +264,21 @@ void main() {
         'data': null
       };
 
+      clearInteractions(bridge);
       didUnloadController.add(null);
       await lifecycleCompleter.future;
 
       verify(bridge.broadcastSerializedEvent(expectedEvent));
+    });
+
+    test('should not broadcast an event if the bridge is not set', () async {
+      bus.reset();
+
+      clearInteractions(bridge);
+      didUnloadController.add(null);
+      await lifecycleCompleter.future;
+
+      verifyZeroInteractions(bridge);
     });
 
     test('should call correct api method', () async {

--- a/test/serializable_test.dart
+++ b/test/serializable_test.dart
@@ -17,11 +17,11 @@ library serializable_module.test.serializable_test;
 
 import 'dart:async';
 
+import 'package:mockito/mockito.dart';
+import 'package:w_module/w_module.dart';
 import 'package:w_module/serializable_module.dart';
 import 'package:w_common/json_serializable.dart' show JsonSerializable;
-import 'package:w_module/w_module.dart';
 import 'package:test/test.dart';
-import 'package:mockito/mockito.dart';
 
 DispatchKey dispatchKey = new DispatchKey('serializable');
 
@@ -166,7 +166,6 @@ void main() {
 
       when(bridge.apiCallReceived).thenReturn(bridgeEventController.stream);
 
-      bus.reset();
       bus.registerModule(module);
       bus.bridge = bridge;
     });

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -31,7 +31,6 @@ Future<Null> main(List<String> args) async {
   ];
   config.copyLicense.directories = directories;
   config.format.directories = directories;
-  config.test.platforms = ['content-shell', 'vm'];
 
   await dev(args);
 }

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -31,6 +31,7 @@ Future<Null> main(List<String> args) async {
   ];
   config.copyLicense.directories = directories;
   config.format.directories = directories;
+  config.test.platforms = ['content-shell', 'vm'];
 
   await dev(args);
 }


### PR DESCRIPTION
## Description
- Added a way to serialize w_modules to allow for communication with other systems (such as a mobile app)

## What was changed
- A separate entry point for a serializable module so all the existing w_module logic does not have any browser specific dependencies.
- Added a `SerializableBus` singleton that registers for events and listens for api calls to modules
- Added a `SerializableModule` class that extends the existing `Module` class that adds needed information to serialize a module
- Added a `Reflectable` class that allows classes and methods to be reflected upon using mirrors.
- Added a `SerializableEvent` and `SerializableEvents` class that allows events to be serializable.
- Unit tests around additions and changes.

Please review: @trentgrover-wf @evanweible-wf @maxwellpeterson-wf 

An actual implementation of these changes can be seen in this [diff](https://github.com/Workiva/w_viewer/compare/master...brianblanchard-wf:MOBILE-2281)