### PR TITLE
RAP-1482 Mix Disposable into LifecycleModule

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -18,10 +18,11 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart' show protected;
+import 'package:w_common/disposable.dart';
 
 /// Intended to be extended by most base module classes in order to provide a
 /// unified lifecycle API.
-abstract class LifecycleModule {
+abstract class LifecycleModule extends Object with Disposable {
   bool _isLoaded = false;
 
   bool _isSuspended = false;
@@ -32,22 +33,25 @@ abstract class LifecycleModule {
 
   // constructor necessary to init load / unload state stream
   LifecycleModule() {
-    _willLoadController = new StreamController<LifecycleModule>.broadcast();
-    _didLoadController = new StreamController<LifecycleModule>.broadcast();
-    _willUnloadController = new StreamController<LifecycleModule>.broadcast();
-    _didUnloadController = new StreamController<LifecycleModule>.broadcast();
-    _willLoadChildModuleController =
-        new StreamController<LifecycleModule>.broadcast();
-    _didLoadChildModuleController =
-        new StreamController<LifecycleModule>.broadcast();
-    _willUnloadChildModuleController =
-        new StreamController<LifecycleModule>.broadcast();
-    _didUnloadChildModuleController =
-        new StreamController<LifecycleModule>.broadcast();
-    _willSuspendController = new StreamController<LifecycleModule>.broadcast();
-    _didSuspendController = new StreamController<LifecycleModule>.broadcast();
-    _willResumeController = new StreamController<LifecycleModule>.broadcast();
-    _didResumeController = new StreamController<LifecycleModule>.broadcast();
+    [
+      _willLoadController = new StreamController<LifecycleModule>.broadcast(),
+      _didLoadController = new StreamController<LifecycleModule>.broadcast(),
+      _willUnloadController = new StreamController<LifecycleModule>.broadcast(),
+      _didUnloadController = new StreamController<LifecycleModule>.broadcast(),
+      _willLoadChildModuleController =
+          new StreamController<LifecycleModule>.broadcast(),
+      _didLoadChildModuleController =
+          new StreamController<LifecycleModule>.broadcast(),
+      _willUnloadChildModuleController =
+          new StreamController<LifecycleModule>.broadcast(),
+      _didUnloadChildModuleController =
+          new StreamController<LifecycleModule>.broadcast(),
+      _willSuspendController =
+          new StreamController<LifecycleModule>.broadcast(),
+      _didSuspendController = new StreamController<LifecycleModule>.broadcast(),
+      _willResumeController = new StreamController<LifecycleModule>.broadcast(),
+      _didResumeController = new StreamController<LifecycleModule>.broadcast()
+    ].forEach(manageStreamController);
 
     _logger = new Logger('w_module');
   }
@@ -283,7 +287,9 @@ abstract class LifecycleModule {
             _didUnloadController.add(this);
             _isLoaded = false;
             _isSuspended = false;
-            completer.complete();
+            super.dispose().then((_) {
+              completer.complete();
+            });
           });
         });
       } else {
@@ -296,6 +302,13 @@ abstract class LifecycleModule {
     }
     return completer.future;
   }
+
+  /// Aliased to [unload].
+  ///
+  /// Deprecated: Use the method [unload] instead.
+  @deprecated
+  @override
+  Future<Null> dispose() => unload();
 
   //--------------------------------------------------------
   // Methods that can be optionally implemented by subclasses
@@ -359,6 +372,12 @@ abstract class LifecycleModule {
   /// has finished unloading.
   @protected
   Future<Null> onUnload() async {}
+
+  /// Deprecated: override [onUnload] instead.
+  @deprecated
+  @protected
+  @override
+  Future<Null> onDispose() async {}
 }
 
 /// Exception thrown when unload fails.

--- a/lib/src/serializable.dart
+++ b/lib/src/serializable.dart
@@ -225,7 +225,8 @@ class SerializableBus {
     event['event'] = eventKey;
 
     if (data is JsonSerializable) {
-      data = (data as JsonSerializable).toJson();
+      JsonSerializable serializeData = data;
+      data = serializeData.toJson();
     }
 
     event['data'] = data;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,21 +9,23 @@ authors:
   - Max Peterson <maxwell.peterson@workiva.com>
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/w_module
+
 dependencies:
-  logging: "^0.11.0"
-  meta: "^1.0.0"
-  w_common: "^1.0.0"
+  logging: ^0.11.0
+  meta: ^1.0.0
+  w_common: ^1.0.0
 
 dev_dependencies:
-  browser: "^0.10.0+2"
-  browser_detect: "^1.0.3"
-  coverage: "^0.7.3"
-  dart_dev: "^1.0.0"
-  dart_style: "^0.2.1"
-  dartdoc: "^0.8.0"
-  mockito: "^1.0.1"
+  browser: ^0.10.0+2
+  browser_detect: ^1.0.3
+  coverage: ^0.7.3
+  dart_dev: ^1.0.0
+  dart_style: ^0.2.1
+  dartdoc: ^0.8.0
+  mockito: ^1.0.1
   react: ">=0.5.0 <0.8.0"
-  test: "^0.12.0"
-  w_flux: "^1.0.0"
+  test: ^0.12.0
+  w_flux: ^1.0.0
+
 environment:
   sdk: ">=1.9.0 <2.0.0"

--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -53,10 +53,10 @@ void main() {
       // The point of this test is to exercise the `where` method which is made available
       // on an action by extending stream and overriding `listen`
       Stream<String> filteredStream = event.where((value) => value == 'water');
-      expectAsync(filteredStream.listen)((payload) {
+      filteredStream.listen(expectAsync1((payload) {
         expect(payload, equals('water'));
         completer.complete();
-      });
+      }));
 
       event('water', key);
       return completer.future;


### PR DESCRIPTION
**Jira Ticket:** [RAP-1482](https://jira.atl.workiva.net/browse/RAP-1482)

## Problem:
We'd like to use `Disposable` in the `LifecycleModule`. This will allow us to properly close the stream controllers that it manages.

## Solution:
1. Mixed in `Disposable`.
1. Aliased `dispose` to `unload` and marked it `@deprecated`. This will help us guide consumers to rely on `unload` instead.
1. Overrode `onDispose` and documented it as deprecated as well.

**Note:** there will be at least two more PRs to follow: one to enforce a single load/unload cycle; and another to make load, unload, suspend, and resume noops when the module is already in the correct state.

## Semantic Versioning:

- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [x] **Minor**
  - [x] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

## +10/QA:
- [ ] CI build passes

## Review:
@Workiva/rich-app-platform-pp 
@Workiva/web-platform-pp 