### PR TITLE
RAP-1483 Only allow one module load/unload cycle

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -150,12 +150,11 @@ abstract class LifecycleModule extends Object with Disposable {
   /// [LifecycleModule] only supports one load/unload cycle. If [load] is called
   /// again after a module has been unloaded, a [StateError] is thrown.
   Future<Null> load() {
-    if (_isUnloadedOrUnloading) {
-      throw new StateError('Module "$name" cannot be reloaded.');
-    }
-
     final completer = new Completer<Null>();
-    if (!_isLoaded) {
+    if (_isUnloadedOrUnloading) {
+      completer
+          .completeError(new StateError('Module "$name" cannot be reloaded.'));
+    } else if (!_isLoaded) {
       _willLoadController.add(this);
       onLoad().then((_) {
         _didLoadController.add(this);

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -24,11 +24,9 @@ import 'package:w_common/disposable.dart';
 /// unified lifecycle API.
 abstract class LifecycleModule extends Object with Disposable {
   bool _isLoaded = false;
-
   bool _isSuspended = false;
-
+  bool _isUnloadedOrUnloading = false;
   Logger _logger;
-
   String _name = 'Module';
 
   // constructor necessary to init load / unload state stream
@@ -148,8 +146,14 @@ abstract class LifecycleModule extends Object with Disposable {
   ///
   /// Calls the onLoad() method, which can be implemented on a Module.
   /// Executes the willLoad and didLoad event streams.
-  /// TODO: Do we want to support re-loading of child modules here?
+  ///
+  /// [LifecycleModule] only supports one load/unload cycle. If [load] is called
+  /// again after a module has been unloaded, a [StateError] is thrown.
   Future<Null> load() {
+    if (_isUnloadedOrUnloading) {
+      throw new StateError('Module "$name" cannot be reloaded.');
+    }
+
     final completer = new Completer<Null>();
     if (!_isLoaded) {
       _willLoadController.add(this);
@@ -279,6 +283,7 @@ abstract class LifecycleModule extends Object with Disposable {
     if (_isLoaded) {
       ShouldUnloadResult canUnload = shouldUnload();
       if (canUnload.shouldUnload) {
+        _isUnloadedOrUnloading = true;
         _willUnloadController.add(this);
         final unloadChildren = _childModules.map((c) => c.unload());
         Future.wait(unloadChildren).then((_) {

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -291,7 +291,7 @@ void main() {
         () async {
       await module.load();
       await module.unload();
-      expect(module.load, throwsStateError);
+      expect(module.load(), throwsStateError);
     });
 
     test(

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -287,6 +287,13 @@ void main() {
       expect(lastLogMessage.level, equals(Level.WARNING));
     });
 
+    test('should throw StateError when attempting to reload a module',
+        () async {
+      await module.load();
+      await module.unload();
+      expect(module.load, throwsStateError);
+    });
+
     test(
         'should trigger suspend events and call onSuspend when module is suspended',
         () async {


### PR DESCRIPTION
**Jira Ticket:** [RAP-1483](https://jira.atl.workiva.net/browse/RAP-1483)

## Problem:
We've decided to only allow one load/unload cycle for a module.

## Solution:
Updated `LifecycleModule.load` to check to see if the module has been through a load/unload cycle before. If it has been, then it now throws a `StateError`.

## +10/QA:
- [x] CI build passes