### PR TITLE
RAP-1484 Enforce LifecycleModule State Transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,14 @@ Method         | Description
 `shouldUnload` | Returns the unloadable state of the `Module` and its child modules as a `ShouldUnloadResult`.  Internally, this executes the module's `onShouldUnload` method.
 `unload`       | Triggers unloading of a `Module` and all of its child modules.  Internally, this executes the module's `shouldUnload` method, and, if that completes successfully, executes the module's `onUnload` method. If unloading is rejected, this method will complete with an error.
 
+![lifecycle module - lifecycle](https://cloud.githubusercontent.com/assets/11619752/21526229/d7a5ae1c-ccdf-11e6-9e95-ff16a83e3a7f.png)
+
+The graphic above illustrates legal lifecycle state transitions. Any state
+transition that is not defined will throw a `StateError`. No-op transitions are
+illustrated with blue arrows. Calling the lifecycle method when the module is
+already in the given state will result in a logger warning. If a no-op is
+performed on a transitioning state the pending transition future is returned.
+
 ### Lifecycle Events
 
 `Module` also exposes lifecycle event streams that an external consumer can listen to:

--- a/lib/w_module.dart
+++ b/lib/w_module.dart
@@ -22,5 +22,5 @@
 library w_module;
 
 export 'package:w_module/src/event.dart';
-export 'package:w_module/src/lifecycle_module.dart';
+export 'package:w_module/src/lifecycle_module.dart' hide LifecycleState;
 export 'package:w_module/src/module.dart';

--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm || browser')
-library w_module.test.event_test;
-
 import 'dart:async';
 
 import 'package:w_module/w_module.dart';

--- a/test/module_test.dart
+++ b/test/module_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm || browser')
-library w_module.test.lifecycle_module_test;
-
 import 'package:w_module/w_module.dart';
 import 'package:test/test.dart';
 
@@ -28,15 +26,15 @@ void main() {
       module = new TestModule();
     });
 
-    test('should return null from api getter by default', () async {
+    test('should return null from api getter by default', () {
       expect(module.api, isNull);
     });
 
-    test('should return null from components getter by default', () async {
+    test('should return null from components getter by default', () {
       expect(module.components, isNull);
     });
 
-    test('should return null from events getter by default', () async {
+    test('should return null from events getter by default', () {
       expect(module.events, isNull);
     });
   });

--- a/test/serializable_test.dart
+++ b/test/serializable_test.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 @TestOn('vm || browser')
-library serializable_module.test.serializable_test;
-
 import 'dart:async';
 
 import 'package:mockito/mockito.dart';


### PR DESCRIPTION
**Jira Ticket:** [RAP-1484](https://jira.atl.workiva.net/browse/RAP-1484)

## Problem:
We should enforce proper transitions between `LifecycleModule` states. The arrows in the following diagram identify valid state transitions. Green arrows represent transitions that will proceed as requested. Blue arrows represent noops.

![lifecycle module - lifecycle](https://cloud.githubusercontent.com/assets/11619752/21526229/d7a5ae1c-ccdf-11e6-9e95-ff16a83e3a7f.png)

## Solution:
Updated `LifecycleModule` to enforce the valid transitions. If a transition will be a noop, log a warning. If an invalid transition is requested a `StateError` is thrown.

## +10/QA:
- [ ] CI build passes