### PR TITLE
RAP-1501 Implement Disposal Via Composition

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,5 +27,10 @@ dev_dependencies:
   test: ^0.12.0
   w_flux: ^1.0.0
 
+dependency_overrides:
+  w_common:
+    git:
+      url: https://github.com/Workiva/w_common.git
+      ref: 33da10e3790f9fb685122393f4321422e5b178c5
 environment:
   sdk: ">=1.9.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ homepage: https://github.com/Workiva/w_module
 dependencies:
   logging: ^0.11.0
   meta: ^1.0.0
-  w_common: ^1.0.0
+  w_common: ^1.2.0
 
 dev_dependencies:
   browser: ^0.10.0+2
@@ -27,10 +27,5 @@ dev_dependencies:
   test: ^0.12.0
   w_flux: ^1.0.0
 
-dependency_overrides:
-  w_common:
-    git:
-      url: https://github.com/Workiva/w_common.git
-      ref: 33da10e3790f9fb685122393f4321422e5b178c5
 environment:
   sdk: ">=1.9.0 <2.0.0"


### PR DESCRIPTION
Problem
---

Disposal of a `LifecycleModule` has been encapsulated as part of the `unload` lifecycle call. In order to provide the disposable management functions to child classes `LifecycleModule` was force to mixin `Disposable` and add deprecated aliases to the 'dispose' and 'onDispose' methods to 'unload' and 'onUnload' respectively. This extends the API of `LifecycleModule` in an inappropriate way that may confuse consumers. In addition, a `LifecycleModule` may be inadvertently maintained in a collection of `Disposable`s or managed by another `Disposable`.

Solution
---

Utilize the `DisposableManager` interface to define the disposable management API for a `LifecycleModule` without having to implement 'dispose' and `onDispose`. Calls to these management functions are proxied to an internal `Disposable` object which the `LifecycleModule` disposes as part of it's `unload` lifecycle call. This ensures child classes can continue to manage disposable entities and that their disposal is done during the unload lifecycle transition as defined by the `LifecycleModule`.

Areas of Impact
---

- Removes deprecated methods from API
- Disposal

Howto QA/+10
---

- [ ] Ensure CI passes

References
---

- /fya @Workiva/web-platform-pp @Workiva/rich-app-platform-pp