### PR TITLE
RAP-1510 Use Enum Value in Noop Warning Message

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -206,7 +206,8 @@ abstract class LifecycleModule implements DisposableManager {
       return _buildNoopResponse(
           isTransitioning: isLoading,
           methodName: 'load',
-          currentState: LifecycleState.loaded);
+          currentState:
+              isLoading ? LifecycleState.loading : LifecycleState.loaded);
     }
 
     if (!isInstantiated) {
@@ -300,7 +301,9 @@ abstract class LifecycleModule implements DisposableManager {
       return _buildNoopResponse(
           isTransitioning: isSuspending,
           methodName: 'suspend',
-          currentState: LifecycleState.suspended);
+          currentState: isSuspending
+              ? LifecycleState.suspending
+              : LifecycleState.suspended);
     }
 
     if (!isLoaded) {
@@ -340,7 +343,8 @@ abstract class LifecycleModule implements DisposableManager {
       return _buildNoopResponse(
           isTransitioning: isResuming,
           methodName: 'resume',
-          currentState: LifecycleState.loaded);
+          currentState:
+              isResuming ? LifecycleState.resuming : LifecycleState.loaded);
     }
 
     if (!isSuspended) {
@@ -405,7 +409,8 @@ abstract class LifecycleModule implements DisposableManager {
       return _buildNoopResponse(
           isTransitioning: isUnloading,
           methodName: 'unload',
-          currentState: LifecycleState.unloaded);
+          currentState:
+              isUnloading ? LifecycleState.unloading : LifecycleState.unloaded);
     }
 
     if (!(isLoaded || isSuspended)) {
@@ -531,7 +536,7 @@ abstract class LifecycleModule implements DisposableManager {
   }
 
   /// Obtains the value of a [LifecycleState] enumeration.
-  String _readableStateName(LifecycleState state) => '$state'.split('.').first;
+  String _readableStateName(LifecycleState state) => '$state'.split('.')[1];
 }
 
 /// Exception thrown when unload fails.

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -49,7 +49,7 @@ class TestLifecycleModule extends LifecycleModule {
     eventList = [];
     mockShouldUnload = true;
 
-    // Mangage disposables
+    // Manage disposables
     manageDisposable(managedDisposable);
     manageDisposer(() {
       _managedDisposerWasCalled = true;
@@ -337,7 +337,7 @@ void main() {
         await gotoState(module, LifecycleState.loading);
         expect(lastLogMessage, isNull);
         await module.load();
-        expect(lastLogMessage, isNotNull);
+        expect(lastLogMessage.message, contains('loading'));
         expect(lastLogMessage.level, equals(Level.WARNING));
       });
 
@@ -345,7 +345,7 @@ void main() {
         await module.load();
         expect(lastLogMessage, isNull);
         await module.load();
-        expect(lastLogMessage, isNotNull);
+        expect(lastLogMessage.message, contains('loaded'));
         expect(lastLogMessage.level, equals(Level.WARNING));
       });
 
@@ -444,7 +444,7 @@ void main() {
         await gotoState(module, LifecycleState.unloading);
         expect(lastLogMessage, isNull);
         await module.unload();
-        expect(lastLogMessage, isNotNull);
+        expect(lastLogMessage.message, contains('unloading'));
         expect(lastLogMessage.level, equals(Level.WARNING));
       });
 
@@ -452,7 +452,7 @@ void main() {
         await gotoState(module, LifecycleState.unloaded);
         expect(lastLogMessage, isNull);
         await module.unload();
-        expect(lastLogMessage, isNotNull);
+        expect(lastLogMessage.message, contains('unloaded'));
         expect(lastLogMessage.level, equals(Level.WARNING));
       });
 
@@ -562,7 +562,7 @@ void main() {
         await gotoState(module, LifecycleState.suspending);
         expect(lastLogMessage, isNull);
         await module.suspend();
-        expect(lastLogMessage, isNotNull);
+        expect(lastLogMessage.message, contains('suspending'));
         expect(lastLogMessage.level, equals(Level.WARNING));
       });
 
@@ -570,7 +570,7 @@ void main() {
         await gotoState(module, LifecycleState.suspended);
         expect(lastLogMessage, isNull);
         await module.suspend();
-        expect(lastLogMessage, isNotNull);
+        expect(lastLogMessage.message, contains('suspended'));
         expect(lastLogMessage.level, equals(Level.WARNING));
       });
 
@@ -653,7 +653,16 @@ void main() {
         module.resume();
         expect(lastLogMessage, isNull);
         await module.resume();
-        expect(lastLogMessage, isNotNull);
+        expect(lastLogMessage.message, contains('resuming'));
+        expect(lastLogMessage.level, equals(Level.WARNING));
+      });
+
+      test('should warn if it is already loaded', () async {
+        await gotoState(module, LifecycleState.loaded);
+        // ignore: unawaited_futures
+        expect(lastLogMessage, isNull);
+        await module.resume();
+        expect(lastLogMessage.message, contains('loaded'));
         expect(lastLogMessage.level, equals(Level.WARNING));
       });
 

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -659,7 +659,6 @@ void main() {
 
       test('should warn if it is already loaded', () async {
         await gotoState(module, LifecycleState.loaded);
-        // ignore: unawaited_futures
         expect(lastLogMessage, isNull);
         await module.resume();
         expect(lastLogMessage.message, contains('loaded'));


### PR DESCRIPTION
Problem
---

The utility function for pretty printing a `LifecycleState` enumeration value is incorrect and returns the left half of the enumeration value, id "LifecycleState.loaded => LifecycleState".

Solution
---

Return the correct portion of the split of a given enumeration.

Tests
---

- Updated tests to confirm warn statement contains the correct values.

Howto QA/+10
---

- [ ] CI passes
- [ ] Attempt to load a w_module instance twice and confirm the logger warning is correct.

References
---

- /fya @Workiva/rich-app-platform-pp @Workiva/web-platform-pp 