### PR TITLE
RAP-1529 Do not allow loadChildModule calls when unloading or unloaded

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -232,16 +232,19 @@ abstract class LifecycleModule implements DisposableManager {
 
   /// Public method to async load a child module and register it
   /// for lifecycle management.
+  ///
+  /// Attempting to load a child module after a module has been unloaded will
+  /// throw a [StateError].
   @protected
   Future<Null> loadChildModule(LifecycleModule newModule) {
     if (_childModules.contains(newModule)) {
-      return new Future(() {});
+      return new Future.value(null);
     }
 
     if (isUnloaded || isUnloading) {
-      final state = isUnloaded ? 'unloaded' : 'unloading';
-      return new Future.error(
-          new StateError('Cannot load child module when module is $state'));
+      var stateLabel = isUnloaded ? 'unloaded' : 'unloading';
+      return new Future.error(new StateError(
+          'Cannot load child module when module is $stateLabel'));
     }
 
     final completer = new Completer<Null>();

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -237,6 +237,13 @@ abstract class LifecycleModule implements DisposableManager {
     if (_childModules.contains(newModule)) {
       return new Future(() {});
     }
+
+    if (isUnloaded || isUnloading) {
+      final state = isUnloaded ? 'unloaded' : 'unloading';
+      return new Future.error(
+          new StateError('Cannot load child module when module is $state'));
+    }
+
     final completer = new Completer<Null>();
     onWillLoadChildModule(newModule);
     _willLoadChildModuleController.add(newModule);


### PR DESCRIPTION
Problem
---

If a module attempts to load a child module while unloading or unloading it may be possible for internal event stream controllers to be added to after they have been closed. This returns an unxepcted exception which may be confusing for consumers.

Solution
---

By making calls to loadChildModule when a module is unloaded or unloading throw a state error indicating it is not allowed consumers better understand the failure.

Howto QA/+10
---

- [ ] Ensure CI passes


References
---

- /fya @Workiva/rich-app-platform-pp @Workiva/web-platform-pp 