### PR TITLE
RAP-1679 Stream Lifecycle Method Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,9 @@ Many examples of `Module` lifecycle behavior and manipulation can be found in th
 ### Lifecycle Methods
 
 `Module` exposes five lifecycle methods that external consumers should use to trigger loading and unloading
-behavior:
+behavior. These methods can return an error or exception thrown by their respective lifecycle handler methods.
+This allows dependencies on a `Module` to respond to failures that occur within the overridden lifecycle 
+behavior.
 
 Method         | Description
 -------------- | ---------------------------------
@@ -293,7 +295,7 @@ Method         | Description
 `suspend`      | Suspends the module and all child modules. While suspended modules should make themselves lightweight and avoid making network requests.
 `resume`       | Brings the module and all child modules out of suspension. Upon resuming, modules should go back to business as usual.
 `shouldUnload` | Returns the unloadable state of the `Module` and its child modules as a `ShouldUnloadResult`.  Internally, this executes the module's `onShouldUnload` method.
-`unload`       | Triggers unloading of a `Module` and all of its child modules.  Internally, this executes the module's `shouldUnload` method, and, if that completes successfully, executes the module's `onUnload` method. If unloading is rejected, this method will complete with an error.
+`unload`       | Triggers unloading of a `Module` and all of its child modules.  Internally, this executes the module's `shouldUnload` method, and, if that completes successfully, executes the module's `onUnload` method. If unloading is rejected, this method will complete with an error. The rejected error will not be added to the `didUnload` lifecycle event stream.
 
 ![lifecycle module - lifecycle](https://cloud.githubusercontent.com/assets/11619752/21526229/d7a5ae1c-ccdf-11e6-9e95-ff16a83e3a7f.png)
 
@@ -305,7 +307,7 @@ performed on a transitioning state the pending transition future is returned.
 
 ### Lifecycle Events
 
-`Module` also exposes lifecycle event streams that an external consumer can listen to:
+`Module` also exposes lifecycle event streams that an external consumer can listen to. If any corresponding lifecycle handler method throws an exception or error it will be added to the corresponding stream. This allows dependencies on a `Module` to provide an `onError` function to handle recovering from a failure within the module implementation.
 
 Event          | Description
 -------------- | ---------------------------------
@@ -320,7 +322,7 @@ Event          | Description
 
 ### Lifecycle Customization
 
-Internally, `Module` contains methods that can be overridden to customize module lifecycle behavior:
+Internally, `Module` contains methods that can be overridden to customize module lifecycle behavior. Any error or exception thrown by these overloaded lifecycle methods will be added to their corresponding lifecycle event stream. This error will be returned to the caller of the corresponding lifecycle method. 
 
 Method           | Description
 ---------------- | ---------------------------------

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -52,7 +52,7 @@ enum LifecycleState {
 /// Intended to be extended by most base module classes in order to provide a
 /// unified lifecycle API.
 abstract class LifecycleModule extends SimpleModule
-    implements DisposableManager {
+    implements DisposableManagerV2 {
   final Disposable _disposableProxy = new Disposable();
   Logger _logger;
   String _name = 'Module';
@@ -162,6 +162,15 @@ abstract class LifecycleModule extends SimpleModule
       _willUnloadChildModuleSubscriptions = {};
   final Map<LifecycleModule, StreamSubscription<LifecycleModule>>
       _didUnloadChildModuleSubscriptions = {};
+
+  @override
+  Timer getManagedPeriodicTimer(
+          Duration duration, void callback(Timer timer)) =>
+      _disposableProxy.getManagedPeriodicTimer(duration, callback);
+
+  @override
+  Timer getManagedTimer(Duration duration, void callback()) =>
+      _disposableProxy.getManagedTimer(duration, callback);
 
   /// Whether the module is currently instantiated.
   bool get isInstantiated => _state == LifecycleState.instantiated;

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -131,7 +131,7 @@ abstract class LifecycleModule extends SimpleModule
   /// Any error or exception thrown during the child [LifecycleModule]'s
   /// [onLoad] call will be emitted.
   ///
-  /// Any error or exception thrown during the parent [LifecycleModule]'safe
+  /// Any error or exception thrown during the parent [LifecycleModule]'s
   /// [onDidLoadChildModule] call will be emitted.
   Stream<LifecycleModule> get didLoadChildModule =>
       _didLoadChildModuleController.stream;
@@ -168,21 +168,21 @@ abstract class LifecycleModule extends SimpleModule
   /// Any error or exception thrown during the child [LifecycleModule]'s
   /// [onUnload] call will be emitted.
   ///
-  /// Any error or exception thrown during the parent [LifecycleModule]'safe
+  /// Any error or exception thrown during the parent [LifecycleModule]'s
   /// [onDidUnloadChildModule] call will be emitted.
   Stream<LifecycleModule> get didUnloadChildModule =>
       _didUnloadChildModuleController.stream;
 
   /// A child [LifecycleModule] is about to be loaded.
   ///
-  /// Any error or exception thrown during the parent [LifecycleModule]'safe
+  /// Any error or exception thrown during the parent [LifecycleModule]'s
   /// [onDidLoadChildModule] call will be emitted.
   Stream<LifecycleModule> get willLoadChildModule =>
       _willLoadChildModuleController.stream;
 
   /// A child [LifecycleModule] is about to be unloaded.
   ///
-  /// Any error or exception thrown during the parent [LifecycleModule]'safe
+  /// Any error or exception thrown during the parent [LifecycleModule]'s
   /// [onDidUnloadChildModule] call will be emitted.
   Stream<LifecycleModule> get willUnloadChildModule =>
       _willUnloadChildModuleController.stream;
@@ -248,8 +248,8 @@ abstract class LifecycleModule extends SimpleModule
   /// StateError is thrown.
   ///
   /// If an [Exception] is thrown during the call to [onLoad] it will be emitted
-  /// on the [didLoad] lifecycle stream. The exception will also be returned as
-  /// the [Future] error value.
+  /// on the [didLoad] lifecycle stream. The returned [Future] will also resolve
+  /// with this exception.
   ///
   /// Note that [LifecycleModule] only supports one load/unload cycle. If [load]
   /// is called after a module has been unloaded, a [StateError] is thrown.
@@ -290,12 +290,17 @@ abstract class LifecycleModule extends SimpleModule
   ///
   /// If an [Exception] is thrown during the call to the parent
   /// [onWillLoadChildModule] it will be emitted on the [willLoadChildModule]
-  /// lifecycle stream. The exception will also be returned as the [Future]
-  /// error value.
+  /// lifecycle stream. The returned [Future] will also resolve with this
+  /// exception.
   ///
   /// If an [Exception] is thrown during the call to the child [onLoad] it will
-  /// be emitted on the [didLoadChildModule] lifecycle stream. The exception
-  /// will also be returned as the [Future] error value.
+  /// be emitted on the [didLoadChildModule] lifecycle stream. The returned
+  /// [Future] will also resolve with this exception.
+  ///
+  /// If an [Exception] is thrown during the call to the parent
+  /// [onDidLoadChildModule] it will be emitted on the [didLoadChildModule]
+  /// lifecycle stream. The returned [Future] will also resolve with this
+  /// exception.
   ///
   /// Attempting to load a child module after a module has been unloaded will
   /// throw a [StateError].
@@ -378,8 +383,12 @@ abstract class LifecycleModule extends SimpleModule
   ///
   /// The [Future] values of all children [suspend] calls will be awaited. The
   /// first child to return an error value will emit the error on the
-  /// [didSuspend] lifecycle stream. This error will also be returned by
-  /// [suspend].
+  /// [didSuspend] lifecycle stream. The returned [Future] will also resolve
+  /// with this exception.
+  ///
+  /// If an [Exception] is thrown during the call to [onSuspend] it will be
+  /// emitted on the [didSuspend] lifecycle stream. The returned [Future] will
+  /// also resolve with this exception.
   ///
   /// If an error or exception is thrown during the call to the parent
   /// [onSuspend] lifecycle method it will be emitted on the [didSuspend]
@@ -432,8 +441,12 @@ abstract class LifecycleModule extends SimpleModule
   ///
   /// The [Future] values of all children [resume] calls will be awaited. The
   /// first child to return an error value will emit the error on the
-  /// [didResume] lifecycle stream. This error will also be returned by
-  /// [resume].
+  /// [didResume] lifecycle stream. The returned [Future] will also resolve with
+  /// this exception.
+  ///
+  /// If an [Exception] is thrown during the call to [onResume] it will be
+  /// emitted on the [didResume] lifecycle stream. The returned [Future] will
+  /// also resolve with this exception.
   ///
   /// If an error or exception is thrown during the call to the parent
   /// [onResume] lifecycle method it will be emitted on the [didResume]
@@ -511,8 +524,12 @@ abstract class LifecycleModule extends SimpleModule
   ///
   /// The [Future] values of all children [unload] calls will be awaited. The
   /// first child to return an error value will emit the error on the
-  /// [didUnload] lifecycle stream. This error will also be returned by
-  /// [unload].
+  /// [didUnload] lifecycle stream. The returned [Future] will also resolve with
+  /// this exception.
+  ///
+  /// If an [Exception] is thrown during the call to [onUnload] it will be
+  /// emitted on the [didUnload] lifecycle stream. The returned [Future] will
+  /// also resolve with this exception.
   ///
   /// If an error or exception is thrown during the call to the parent
   /// [onUnload] lifecycle method it will be emitted on the [didUnload]

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -53,11 +53,28 @@ enum LifecycleState {
 /// unified lifecycle API.
 abstract class LifecycleModule extends SimpleModule
     implements DisposableManagerV2 {
+  List<LifecycleModule> _childModules = [];
+  StreamController<LifecycleModule> _didLoadChildModuleController;
+  StreamController<LifecycleModule> _didLoadController;
+  StreamController<LifecycleModule> _didResumeController;
+  StreamController<LifecycleModule> _didSuspendController;
+  StreamController<LifecycleModule> _didUnloadChildModuleController;
+  final Map<LifecycleModule, StreamSubscription<LifecycleModule>>
+      _didUnloadChildModuleSubscriptions = {};
+  StreamController<LifecycleModule> _didUnloadController;
   final Disposable _disposableProxy = new Disposable();
   Logger _logger;
   String _name = 'Module';
   LifecycleState _state = LifecycleState.instantiated;
   Future<Null> _transitionFuture;
+  StreamController<LifecycleModule> _willLoadChildModuleController;
+  StreamController<LifecycleModule> _willLoadController;
+  StreamController<LifecycleModule> _willResumeController;
+  StreamController<LifecycleModule> _willSuspendController;
+  StreamController<LifecycleModule> _willUnloadChildModuleController;
+  final Map<LifecycleModule, StreamSubscription<LifecycleModule>>
+      _willUnloadChildModuleSubscriptions = {};
+  StreamController<LifecycleModule> _willUnloadController;
 
   // constructor necessary to init load / unload state stream
   LifecycleModule() {
@@ -101,67 +118,86 @@ abstract class LifecycleModule extends SimpleModule
   }
 
   /// List of child components so that lifecycle can iterate over them as needed
-  List<LifecycleModule> _childModules = [];
   Iterable<LifecycleModule> get childModules => _childModules;
 
-  // Broadcast streams for the module's lifecycle events.
-
-  /// Event dispatched at beginning of module.load() logic
-  StreamController<LifecycleModule> _willLoadController;
-  Stream<LifecycleModule> get willLoad => _willLoadController.stream;
-
-  /// Event dispatched at end of module.load() logic
-  StreamController<LifecycleModule> _didLoadController;
+  /// The [LifecycleModule] was loaded.
+  ///
+  /// Any error or exception thrown during the [LifecycleModule]'s
+  /// [onLoad] call will be emitted.
   Stream<LifecycleModule> get didLoad => _didLoadController.stream;
 
-  /// Event dispatched at the beginning of module.loadChildModule() logic
-  StreamController<LifecycleModule> _willLoadChildModuleController;
-  Stream<LifecycleModule> get willLoadChildModule =>
-      _willLoadChildModuleController.stream;
-
-  /// Event dispatched at end of module.loadChildModule() logic
-  StreamController<LifecycleModule> _didLoadChildModuleController;
+  /// A child [LifecycleModule] was loaded.
+  ///
+  /// Any error or exception thrown during the child [LifecycleModule]'s
+  /// [onLoad] call will be emitted.
+  ///
+  /// Any error or exception thrown during the parent [LifecycleModule]'safe
+  /// [onDidLoadChildModule] call will be emitted.
   Stream<LifecycleModule> get didLoadChildModule =>
       _didLoadChildModuleController.stream;
 
-  /// Event dispatched before a child module is unloaded
-  StreamController<LifecycleModule> _willUnloadChildModuleController;
-  Stream<LifecycleModule> get willUnloadChildModule =>
-      _willUnloadChildModuleController.stream;
+  /// The [LifecycleModule] was resumed.
+  ///
+  /// Any error or exception thrown during the child [LifecycleModule]'s
+  /// [resume] call will be emitted.
+  ///
+  /// Any error or exception thrown during the [LifecycleModule]'s
+  /// [onResume] call will be emitted.
+  Stream<LifecycleModule> get didResume => _didResumeController.stream;
 
-  /// Event dispatched after a child module is unloaded
-  StreamController<LifecycleModule> _didUnloadChildModuleController;
+  /// The [LifecycleModule] was suspended.
+  ///
+  /// Any error or exception thrown during the child [LifecycleModule]'s
+  /// [suspend] call will be emitted.
+  ///
+  /// Any error or exception thrown during the [LifecycleModule]'s
+  /// [onSuspend] call will be emitted.
+  Stream<LifecycleModule> get didSuspend => _didSuspendController.stream;
+
+  /// The [LifecycleModule] was unloaded.
+  ///
+  /// Any error or exception thrown during the child [LifecycleModule]'s
+  /// [unload] call will be emitted.
+  ///
+  /// Any error or exception thrown during the [LifecycleModule]'s
+  /// [onUnload] call will be emitted.
+  Stream<LifecycleModule> get didUnload => _didUnloadController.stream;
+
+  /// A child [LifecycleModule] was unloaded.
+  ///
+  /// Any error or exception thrown during the child [LifecycleModule]'s
+  /// [onUnload] call will be emitted.
+  ///
+  /// Any error or exception thrown during the parent [LifecycleModule]'safe
+  /// [onDidUnloadChildModule] call will be emitted.
   Stream<LifecycleModule> get didUnloadChildModule =>
       _didUnloadChildModuleController.stream;
 
-  /// Event dispatched at the beginning of the module.suspend() logic
-  StreamController<LifecycleModule> _willSuspendController;
-  Stream<LifecycleModule> get willSuspend => _willSuspendController.stream;
+  /// A child [LifecycleModule] is about to be loaded.
+  ///
+  /// Any error or exception thrown during the parent [LifecycleModule]'safe
+  /// [onDidLoadChildModule] call will be emitted.
+  Stream<LifecycleModule> get willLoadChildModule =>
+      _willLoadChildModuleController.stream;
 
-  /// Event dispatched at the end of the module.suspend() logic
-  StreamController<LifecycleModule> _didSuspendController;
-  Stream<LifecycleModule> get didSuspend => _didSuspendController.stream;
+  /// A child [LifecycleModule] is about to be unloaded.
+  ///
+  /// Any error or exception thrown during the parent [LifecycleModule]'safe
+  /// [onDidUnloadChildModule] call will be emitted.
+  Stream<LifecycleModule> get willUnloadChildModule =>
+      _willUnloadChildModuleController.stream;
 
-  /// Event dispatched at the beginning of the module.resume() logic
-  StreamController<LifecycleModule> _willResumeController;
+  /// The [LifecycleModule] is about to be resumed.
   Stream<LifecycleModule> get willResume => _willResumeController.stream;
 
-  /// Event dispatched at the end of the module.resume() logic
-  StreamController<LifecycleModule> _didResumeController;
-  Stream<LifecycleModule> get didResume => _didResumeController.stream;
-
-  /// Event dispatched at beginning of module.unload() logic
-  StreamController<LifecycleModule> _willUnloadController;
+  /// The [LifecycleModule] is about to be unloaded.
   Stream<LifecycleModule> get willUnload => _willUnloadController.stream;
 
-  /// Event dispatched at end of module.unload() logic
-  StreamController<LifecycleModule> _didUnloadController;
-  Stream<LifecycleModule> get didUnload => _didUnloadController.stream;
+  /// The [LifecycleModule] is about to be loaded.
+  Stream<LifecycleModule> get willLoad => _willLoadController.stream;
 
-  final Map<LifecycleModule, StreamSubscription<LifecycleModule>>
-      _willUnloadChildModuleSubscriptions = {};
-  final Map<LifecycleModule, StreamSubscription<LifecycleModule>>
-      _didUnloadChildModuleSubscriptions = {};
+  /// The [LifecycleModule] is about to be suspended.
+  Stream<LifecycleModule> get willSuspend => _willSuspendController.stream;
 
   @override
   Timer getManagedPeriodicTimer(
@@ -211,6 +247,10 @@ abstract class LifecycleModule extends SimpleModule
   /// and the method is a noop. If the module is in any other state, a
   /// StateError is thrown.
   ///
+  /// If an [Exception] is thrown during the call to [onLoad] it will be emitted
+  /// on the [didLoad] lifecycle stream. The exception will also be returned as
+  /// the [Future] error value.
+  ///
   /// Note that [LifecycleModule] only supports one load/unload cycle. If [load]
   /// is called after a module has been unloaded, a [StateError] is thrown.
   Future<Null> load() {
@@ -247,6 +287,15 @@ abstract class LifecycleModule extends SimpleModule
 
   /// Public method to async load a child module and register it
   /// for lifecycle management.
+  ///
+  /// If an [Exception] is thrown during the call to the parent
+  /// [onWillLoadChildModule] it will be emitted on the [willLoadChildModule]
+  /// lifecycle stream. The exception will also be returned as the [Future]
+  /// error value.
+  ///
+  /// If an [Exception] is thrown during the call to the child [onLoad] it will
+  /// be emitted on the [didLoadChildModule] lifecycle stream. The exception
+  /// will also be returned as the [Future] error value.
   ///
   /// Attempting to load a child module after a module has been unloaded will
   /// throw a [StateError].
@@ -326,6 +375,15 @@ abstract class LifecycleModule extends SimpleModule
   /// the module is in the suspended or suspending state a warning is logged and
   /// the method is a noop. If the module is in any other state, a StateError is
   /// thrown.
+  ///
+  /// The [Future] values of all children [suspend] calls will be awaited. The
+  /// first child to return an error value will emit the error on the
+  /// [didSuspend] lifecycle stream. This error will also be returned by
+  /// [suspend].
+  ///
+  /// If an error or exception is thrown during the call to the parent
+  /// [onSuspend] lifecycle method it will be emitted on the [didSuspend]
+  /// lifecycle stream. The error will also be returned by [suspend].
   Future<Null> suspend() {
     if (isSuspended || isSuspending) {
       return _buildNoopResponse(
@@ -371,6 +429,15 @@ abstract class LifecycleModule extends SimpleModule
   /// state. If the module is in the resuming state a warning is logged and the
   /// method is a noop. If the module is in any other state, a StateError is
   /// thrown.
+  ///
+  /// The [Future] values of all children [resume] calls will be awaited. The
+  /// first child to return an error value will emit the error on the
+  /// [didResume] lifecycle stream. This error will also be returned by
+  /// [resume].
+  ///
+  /// If an error or exception is thrown during the call to the parent
+  /// [onResume] lifecycle method it will be emitted on the [didResume]
+  /// lifecycle stream. The error will also be returned by [resume].
   Future<Null> resume() {
     if (isLoaded || isResuming) {
       return _buildNoopResponse(
@@ -434,12 +501,22 @@ abstract class LifecycleModule extends SimpleModule
   ///
   /// Calls shouldUnload(), and, if that completes successfully, continues to
   /// call onUnload() on the module and all registered child modules. If
-  /// unloading is rejected, this method will complete with an error.
+  /// unloading is rejected, this method will complete with an error. The rejection
+  /// error will not be added to the [didUnload] lifecycle event stream.
   ///
   /// Initiates the unload process when the module is in the loaded or suspended
   /// state. If the module is in the unloading or unloaded state a warning is
   /// logged and the method is a noop. If the module is in any other state, a
   /// StateError is thrown.
+  ///
+  /// The [Future] values of all children [unload] calls will be awaited. The
+  /// first child to return an error value will emit the error on the
+  /// [didUnload] lifecycle stream. This error will also be returned by
+  /// [unload].
+  ///
+  /// If an error or exception is thrown during the call to the parent
+  /// [onUnload] lifecycle method it will be emitted on the [didUnload]
+  /// lifecycle stream. The error will also be returned by [unload].
   Future<Null> unload() {
     if (isUnloaded || isUnloading) {
       return _buildNoopResponse(

--- a/lib/src/simple_module.dart
+++ b/lib/src/simple_module.dart
@@ -58,7 +58,7 @@ abstract class SimpleModule {
   Object get events => null;
 }
 
-/// Standard [Module.components] class. If a module implements a custom class
+/// Standard [ModuleComponents] class. If a module implements a custom class
 /// for its components, it should extend [ModuleComponents].
 abstract class ModuleComponents {
   /// The default UI component

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ homepage: https://github.com/Workiva/w_module
 dependencies:
   logging: ^0.11.0
   meta: ^1.0.0
-  w_common: ^1.2.0
+  w_common: ^1.3.0
 
 dev_dependencies:
   browser: ^0.10.0+2


### PR DESCRIPTION
## Problem

It is not possible for subscribers of lifecycle events to be aware of errors returned by the associated lifecycle method. For instance, an object may listen to the onUnload event in order to cleanup its state with respect to the a given module. If that module throws during `onLoad` the parent object would never receive the didUnload event and would maintain state related to the given module indefinitely. Consumers of a LifecycleModule should be able to react to errors thrown during lifecycle methods.

## Solution

Capture all errors returned by the lifecycle methods and add them to the corresponding lifecycle stream. This allows consumers of a module to listen to a lifecycle stream and provide an `onError` handler which allows them to deal with the error in their own special way. If an `onError` is not provided the error will be emitted as an unhandled exception in the Zone of the execution context.

## Howto Test

- [ ] Ensure CI passes

## References
- /fya
   - @Workiva/rich-app-platform-pp 
   - @Workiva/web-platform-pp 