### PR TITLE
WP-3859 Make Events closable. Add EventsCollection base class.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2015 Workiva Inc.
+Copyright 2017 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 w_module
-Copyright 2015 Workiva Inc.
+Copyright 2017 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -226,6 +226,34 @@ class SampleStore extends Store {
 }
 ```
 
+To assist in properly disposing of `Event` instances, `w_module` provides an
+`EventsCollection` base class that extends
+[`Disposable` from the `w_common` package](https://github.com/Workiva/w_common)
+with an additional `manageEvent()` method. Colocating related events in an
+`EventsCollection` makes it trivial to close all `Event` instances by disposing
+the `EventsCollection` instance.
+
+```dart
+final key = new DispatchKey('example');
+
+class ExampleEvents extends EventsCollection {
+  final Event<String> eventA = new Event<String>(key);
+  final Event<String> eventB = new Event<String>(key);
+
+  ExampleEvents() : super(key) {
+    [
+      eventA,
+      eventB,
+    ].forEach(manageEvent);
+  }
+}
+
+main() async {
+  final eventsCollection = new EventsCollection();
+  await eventsCollection.dispose();
+  // All Events on the collection should now be closed.
+}
+```
 
 ### Components
 

--- a/example/index.html
+++ b/example/index.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2015 Workiva Inc.
+Copyright 2017 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/example/panel/index.html
+++ b/example/panel/index.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2015 Workiva Inc.
+Copyright 2017 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/example/panel/modules/basic_module.dart
+++ b/example/panel/modules/basic_module.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/panel/modules/data_load_async_module.dart
+++ b/example/panel/modules/data_load_async_module.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/panel/modules/data_load_blocking_module.dart
+++ b/example/panel/modules/data_load_blocking_module.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/panel/modules/deferred_heavy_lifter_implementation.dart
+++ b/example/panel/modules/deferred_heavy_lifter_implementation.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/panel/modules/deferred_heavy_lifter_interface.dart
+++ b/example/panel/modules/deferred_heavy_lifter_interface.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/panel/modules/deferred_module.dart
+++ b/example/panel/modules/deferred_module.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/panel/modules/flux_module.dart
+++ b/example/panel/modules/flux_module.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/panel/modules/hierarchy_module.dart
+++ b/example/panel/modules/hierarchy_module.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/panel/modules/lifecycle_echo_module.dart
+++ b/example/panel/modules/lifecycle_echo_module.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/panel/modules/panel_module.dart
+++ b/example/panel/modules/panel_module.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/panel/modules/reject_module.dart
+++ b/example/panel/modules/reject_module.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/panel/panel_app.css
+++ b/example/panel/panel_app.css
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Workiva Inc.
+ * Copyright 2017 Workiva Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example/panel/panel_app.dart
+++ b/example/panel/panel_app.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/random_color/index.html
+++ b/example/random_color/index.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2015 Workiva Inc.
+Copyright 2017 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/example/random_color/random_color.dart
+++ b/example/random_color/random_color.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/serializable_module.dart
+++ b/lib/serializable_module.dart
@@ -1,4 +1,4 @@
-// Copyright 2016 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -41,12 +41,6 @@ class Event<T> extends Stream<T> {
   /// be dispatched when this is `true`.
   bool get isClosed => _streamController.isClosed;
 
-  /// Sink where new items to this event stream are added.
-  Sink<T> get _sink => _streamController.sink;
-
-  /// Underlying stream that listeners subscribe to.
-  Stream<T> get _stream => _streamController.stream;
-
   /// Closes the Event stream, telling it that no further events will be
   /// dispatched.
   ///
@@ -64,7 +58,7 @@ class Event<T> extends Stream<T> {
   @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
-    return _stream.listen(onData,
+    return _streamController.stream.listen(onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 
@@ -76,7 +70,7 @@ class Event<T> extends Stream<T> {
           'Event dispatch expected the "${_key.name}" key but received the '
           '"${key.name}" key.');
     }
-    _sink.add(payload);
+    _streamController.add(payload);
   }
 }
 

--- a/lib/src/events_collection.dart
+++ b/lib/src/events_collection.dart
@@ -1,0 +1,55 @@
+// Copyright 2017 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:meta/meta.dart';
+import 'package:w_common/disposable.dart';
+
+import 'package:w_module/src/event.dart';
+
+/// A base class for a collection of [Event] instances that are all tied to the
+/// same [DispatchKey].
+///
+/// Use this class to colocate related [Event] instances and to make disposal of
+/// these [Event]s easier.
+///
+///     final key = new DispatchKey('example');
+///
+///     class ExampleEvents extends EventsCollection {
+///       final Event<String> eventA = new Event<String>(key);
+///       final Event<String> eventB = new Event<String>(key);
+///
+///       ExampleEvents() : super(key) {
+///         [
+///           eventA,
+///           eventB,
+///         ].forEach(manageEvent);
+///       }
+///     }
+class EventsCollection extends Disposable {
+  /// The key that every [Event] instance included as a part of this
+  /// [EventsCollection] should be tied to.
+  ///
+  /// This allows [manageEvent] to close the aforementioned [Event]s.
+  final DispatchKey _key;
+
+  EventsCollection(DispatchKey key) : _key = key;
+
+  /// Registers an [Event] to be closed when this [EventsCollection] is
+  /// disposed.
+  @mustCallSuper
+  @protected
+  void manageEvent(Event event) {
+    manageDisposer(() => event.close(_key));
+  }
+}

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/serializable.dart
+++ b/lib/src/serializable.dart
@@ -1,4 +1,4 @@
-// Copyright 2016 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/simple_module.dart
+++ b/lib/src/simple_module.dart
@@ -1,3 +1,17 @@
+// Copyright 2017 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 library w_module.src.simple_module;
 
 /// A [SimpleModule] encapsulates a well-scoped logical unit of functionality and

--- a/lib/w_module.dart
+++ b/lib/w_module.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 library w_module;
 
 export 'package:w_module/src/event.dart';
+export 'package:w_module/src/events_collection.dart';
 export 'package:w_module/src/lifecycle_module.dart' hide LifecycleState;
 export 'package:w_module/src/module.dart';
 export 'package:w_module/src/simple_module.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,13 +19,13 @@ dev_dependencies:
   browser: ^0.10.0+2
   browser_detect: ^1.0.3
   coverage: ^0.7.3
-  dart_dev: ^1.0.0
+  dart_dev: ^1.7.2
   dart_style: ^0.2.1
-  dartdoc: ^0.8.0
+  dartdoc: ^0.9.0
   mockito: ^1.0.1
-  react: ">=0.5.0 <0.8.0"
+  react: '>=0.5.0 <0.8.0'
   test: ^0.12.0
   w_flux: ^1.0.0
 
 environment:
-  sdk: ">=1.9.0 <2.0.0"
+  sdk: '>=1.9.0 <2.0.0'

--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -81,6 +81,27 @@ void main() {
       event('good', key);
 
       await completer.future;
+    });
+
+    test('should be closable', () async {
+      expect(event.isClosed, isFalse);
+      await event.close(key);
+      expect(event.isClosed, isTrue);
+    });
+
+    test('should only allow closing with correct key', () async {
+      // Create a new dispatch key that should not work for this event.
+      DispatchKey incorrectKey = new DispatchKey('incorrect');
+
+      expect(event.close(incorrectKey), throwsArgumentError);
+    });
+
+    test('should now allow events to be dispatched after being closed',
+        () async {
+      await event.close(key);
+      expect(() {
+        event('too late', key);
+      }, throwsStateError);
     });
   });
 }

--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -96,7 +96,7 @@ void main() {
       expect(event.close(incorrectKey), throwsArgumentError);
     });
 
-    test('should now allow events to be dispatched after being closed',
+    test('should not allow events to be dispatched after being closed',
         () async {
       await event.close(key);
       expect(() {

--- a/test/events_collection_test.dart
+++ b/test/events_collection_test.dart
@@ -1,0 +1,45 @@
+// Copyright 2017 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm || browser')
+import 'package:test/test.dart';
+import 'package:w_module/w_module.dart';
+
+final _key = new DispatchKey('test');
+
+class TestEvents extends EventsCollection {
+  final Event<String> eventA = new Event<String>(_key);
+  final Event<String> eventB = new Event<String>(_key);
+
+  TestEvents() : super(_key) {
+    [
+      eventA,
+      eventB,
+    ].forEach(manageEvent);
+  }
+}
+
+void main() {
+  group('EventsCollection', () {
+    test('manageEvent() should close Events when the collection is disposed',
+        () async {
+      final eventsCollection = new TestEvents();
+      expect(eventsCollection.eventA.isClosed, isFalse);
+      expect(eventsCollection.eventB.isClosed, isFalse);
+      await eventsCollection.dispose();
+      expect(eventsCollection.eventA.isClosed, isTrue);
+      expect(eventsCollection.eventB.isClosed, isTrue);
+    });
+  });
+}

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/module_test.dart
+++ b/test/module_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/serializable_test.dart
+++ b/test/serializable_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2016 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/simple_module_test.dart
+++ b/test/simple_module_test.dart
@@ -1,3 +1,17 @@
+// Copyright 2017 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 @TestOn('vm || browser')
 import 'package:test/test.dart';
 

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Issue
The `Event` class offered no public API for disposing/closing, which means that the underlying StreamController could not be closed.

## Changes
- Make `Event` closable via a `close()` method similar to `StreamController.close()`, except that it is protected by the `DispatchKey`.
- Add an `EventsCollection` base class for colocating related `Event` instances that also makes disposal of said events easier via a `manageEvent()` method.
- **Bonus:** updated the `LifecycleModule` class to implement the latest `DisposableManagerV3` interface.
- **Bonus:** updated and applied the license to all files

## Testing
- [ ] CI passes

## Code Review
@Workiva/web-platform-pp 
@Workiva/rich-app-platform-pp 