### PR TITLE
WP-3897 Bump lower bound on w_common dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ homepage: https://github.com/Workiva/w_module
 dependencies:
   logging: ^0.11.0
   meta: ^1.0.0
-  w_common: ^1.3.0
+  w_common: ^1.4.0
 
 dev_dependencies:
   browser: ^0.10.0+2


### PR DESCRIPTION
## Issue

#73 added a dependency on code from the latest w_common (1.4.0) but I didn't correctly raise the lower bound.

## Solution

Raise the lower bound of w_common to 1.4.0 so that a `pub get` with the latest w_module also pulls in the correct version of w_common.

## Testing
- [ ] CI passes

## Code Review
@Workiva/web-platform-pp @Workiva/rich-app-platform-pp 