### PR TITLE
WP-3864 Release w_module 1.2.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_module
-version: 1.2.0
+version: 1.2.1
 description: Base module classes with a well defined lifecycle for modular Dart applications.
 authors:
   - Workiva Client Platform Team <team-clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [WP-3897 Bump lower bound on w_common dependency](https://github.com/Workiva/w_module/pull/78)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_module/compare/1.2.0...version-bump-w_module-1-2-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_module/compare/1.2.0...1.2.1