### PR TITLE
RAP-1850 Await Loading, Suspending, and Resuming State Transitions

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -405,10 +405,14 @@ abstract class LifecycleModule extends SimpleModule
               : LifecycleState.suspended);
     }
 
-    if (!(isLoaded || isLoading || isResuming || isSuspended)) {
+    if (!(isLoaded || isLoading || isResuming)) {
       return _buildIllegalTransitionResponse(
           targetState: LifecycleState.suspended,
-          allowedStates: [LifecycleState.loaded, LifecycleState.resuming]);
+          allowedStates: [
+            LifecycleState.loaded,
+            LifecycleState.loading,
+            LifecycleState.resuming
+          ]);
     }
     var previousTransition = _transition?.future;
     _transition = new Completer<Null>();


### PR DESCRIPTION
## Problem

The current implementation does not allow state transitions to occur while a transition is in progress. For instance, a consumer cannot call suspend and unload synchronously as unloading is not allowed when a module is suspending. Unloading **is** valid when a module is suspended though. If a consumer fails to await the suspend, the LifecycleModule should wait for the transition to complete and then proceed to unload.


## Solution

Any transitioning state that is resolving to a valid state should be awaited in the event of a state change. For example, if a consumer `suspend`s and `unload`s in the same synchronous block, the unload should await the completion of the suspension before proceeding. The state of the module changes from isSuspending  to isUnloading so subsequent state changes must respect legal transitions. The lifecycle events expected from suspend and unload fire in order as if the consumer had awaited the suspend call before unloading.

![transitions](https://cloud.githubusercontent.com/assets/11619752/21526229/d7a5ae1c-ccdf-11e6-9e95-ff16a83e3a7f.png)

The implicit transitions illustrated above are now allowed as permitted by their associated explicit transition. Unload will wait for loading, suspending, and resuming transitions to complete before unloading. Suspend and resume will await resuming and suspending transitions respectively.

## Howto Test
- [ ] CI Passes

## References
- /fya @Workiva/rich-app-platform-pp @Workiva/web-platform-pp 