### PR TITLE
RAP-2057 Fix double unload bug

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -758,8 +758,7 @@ abstract class LifecycleModule extends SimpleModule
       }
       _didUnloadController.add(this);
       await _didUnloadController.close();
-    } on ModuleUnloadCanceledException catch (error, stackTrace) {
-      _didUnloadController.addError(error, stackTrace);
+    } on ModuleUnloadCanceledException catch (error, _) {
       rethrow;
     } catch (error, stackTrace) {
       _didUnloadController.addError(error, stackTrace);

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -687,9 +687,11 @@ abstract class LifecycleModule extends SimpleModule
         await pendingTransition;
       }
       _willResumeController.add(this);
+      List<Future<Null>> childResumeFutures = <Future<Null>>[];
       for (var child in _childModules.toList()) {
-        await child.resume();
+        childResumeFutures.add(child.resume());
       }
+      await Future.wait(childResumeFutures);
       await onResume();
       if (_state == LifecycleState.resuming) {
         _state = LifecycleState.loaded;
@@ -708,9 +710,11 @@ abstract class LifecycleModule extends SimpleModule
         await pendingTransition;
       }
       _willSuspendController.add(this);
+      List<Future<Null>> childSuspendFutures = <Future<Null>>[];
       for (var child in _childModules.toList()) {
-        await child.suspend();
+        childSuspendFutures.add(child.suspend());
       }
+      await Future.wait(childSuspendFutures);
       await onSuspend();
       if (_state == LifecycleState.suspending) {
         _state = LifecycleState.suspended;
@@ -739,10 +743,12 @@ abstract class LifecycleModule extends SimpleModule
             shouldUnloadResult.messagesAsString());
       }
       _willUnloadController.add(this);
+      List<Future<Null>> childUnloadFutures = <Future<Null>>[];
       for (var child in _childModules.toList()) {
-        await child.unload();
+        childUnloadFutures.add(child.unload());
       }
       _childModules.clear();
+      await Future.wait(childUnloadFutures);
       await onUnload();
       await _disposableProxy.dispose();
       if (_state == LifecycleState.unloading) {

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -752,8 +752,12 @@ abstract class LifecycleModule extends SimpleModule
       }
       _didUnloadController.add(this);
       await _didUnloadController.close();
+    } on ModuleUnloadCanceledException catch (error, stackTrace) {
+      _didUnloadController.addError(error, stackTrace);
+      rethrow;
     } catch (error, stackTrace) {
       _didUnloadController.addError(error, stackTrace);
+      await _didUnloadController.close();
       rethrow;
     }
   }

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -65,6 +65,7 @@ abstract class LifecycleModule extends SimpleModule
   final Disposable _disposableProxy = new Disposable();
   Logger _logger;
   String _name = 'Module';
+  LifecycleState _previousState;
   LifecycleState _state = LifecycleState.instantiated;
   Completer<Null> _transition;
   StreamController<LifecycleModule> _willLoadChildModuleController;
@@ -541,6 +542,7 @@ abstract class LifecycleModule extends SimpleModule
     }
 
     var pendingTransition = _transition?.future;
+    _previousState = _state;
     _state = LifecycleState.unloading;
     _transition = new Completer<Null>();
 
@@ -725,6 +727,8 @@ abstract class LifecycleModule extends SimpleModule
 
       ShouldUnloadResult shouldUnloadResult = shouldUnload();
       if (!shouldUnloadResult.shouldUnload) {
+        _state = _previousState;
+        _previousState = null;
         // reject with shouldUnload messages
         throw new ModuleUnloadCanceledException(
             shouldUnloadResult.messagesAsString());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dev_dependencies:
   browser: ^0.10.0+2
   coverage: ^0.7.3
   dart_dev: ^1.7.2
-  dart_style: ^0.2.1
+  dart_style: ^0.2.16
   dartdoc: ^0.9.0
   mockito: ^1.0.1
   react: '>=0.5.0 <0.8.0'

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -1023,6 +1023,15 @@ void main() {
           expect(parentModule.suspend(),
               throwsA(same(childModule.onSuspendError)));
         });
+
+        test('should still suspend other children', () async {
+          var secondChildModule = new TestLifecycleModule();
+          await parentModule.loadChildModule(secondChildModule);
+          try {
+            await parentModule.suspend();
+          } catch (_) {}
+          expect(secondChildModule.isSuspended, isTrue);
+        });
       });
     });
 
@@ -1056,6 +1065,15 @@ void main() {
                   expect(error, same(childModule.onResumeError))));
           expect(
               parentModule.resume(), throwsA(same(childModule.onResumeError)));
+        });
+
+        test('should still resume other children', () async {
+          var secondChildModule = new TestLifecycleModule();
+          await parentModule.loadChildModule(secondChildModule);
+          try {
+            await parentModule.resume();
+          } catch (_) {}
+          expect(secondChildModule.isSuspended, isFalse);
         });
       });
     });
@@ -1108,6 +1126,20 @@ void main() {
           }));
           expect(
               parentModule.unload(), throwsA(same(childModule.onUnloadError)));
+        });
+
+        test('should still unload other children', () async {
+          var secondChildModule = new TestLifecycleModule();
+          await parentModule.loadChildModule(secondChildModule);
+          parentModule.didUnload.listen((LifecycleModule _) {},
+              onError: expectAsync2((Error error, StackTrace stackTrace) {
+            expect(error, same(childModule.onUnloadError));
+            expect(stackTrace, isNotNull);
+          }));
+          try {
+            await parentModule.unload();
+          } catch (_) {}
+          expect(secondChildModule.isUnloaded, isTrue);
         });
       });
 

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -595,6 +595,20 @@ void main() {
         expect(module.isUnloaded, isTrue);
       });
 
+      test(
+          'should not dispatch willUnload or didUnload if shouldUnload completes false',
+          () async {
+        module.willUnload.listen(expectAsync1((_) {}, count: 0));
+        module.didUnload.listen(expectAsync1((_) {}, count: 0));
+        await module.load();
+        module.eventList.clear();
+        module.mockShouldUnload = false;
+        try {
+          await module.unload();
+        } on ModuleUnloadCanceledException catch (_) {}
+        expect(module.isLoaded, isTrue);
+      });
+
       test('should dispose managed disposables', () async {
         await module.load();
         expect(module.managedDisposable.isDisposed, isFalse);

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -573,6 +573,8 @@ void main() {
         expect(error, isNotNull);
         expect(error.message, equals(shouldUnloadError));
         expect(module.eventList, equals(['onShouldUnload']));
+        expect(module.isUnloading, isFalse);
+        expect(module.isLoaded, isTrue);
       });
 
       test('should dispose managed disposables', () async {

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -573,8 +573,26 @@ void main() {
         expect(error, isNotNull);
         expect(error.message, equals(shouldUnloadError));
         expect(module.eventList, equals(['onShouldUnload']));
-        expect(module.isUnloading, isFalse);
         expect(module.isLoaded, isTrue);
+      });
+
+      test('should succeed on second attempt if shouldUnload completes true',
+          () async {
+        await module.load();
+        module.eventList.clear();
+        module.mockShouldUnload = false;
+        var error;
+        try {
+          await module.unload();
+        } on ModuleUnloadCanceledException catch (e) {
+          error = e;
+        }
+        expect(error, isNotNull);
+        expect(module.isLoaded, isTrue);
+
+        module.mockShouldUnload = true;
+        await module.unload();
+        expect(module.isUnloaded, isTrue);
       });
 
       test('should dispose managed disposables', () async {


### PR DESCRIPTION
[Jira Ticket](https://jira.atl.workiva.net/browse/RAP-2057)

## Problem

A bug was reported by @josephelliot-wk in which LifecycleModule throws if an unload was attempted and rejected because a child module returned false from its shouldUnload method.
The problem is that we are leaving the module in the unloading state after a rejected unload when we should probably be moving it back into the loaded state (or not moving it to unloading until after the shouldUnload check has passed).

## Solution

Ensure that the state is reset to its previous state if the unload is rejected. We have to do this in the async `_unload` to keep the semantics the same as they were previously (transition to unloading happens immediately).

I updated one of the tests to guard against regressions.

## Potential Regressions

State changes. These are well tested.

## Tests

Added and/or updated.

## QA / +10

1. Checkout the branch.
2. Update dependencies.
3. Unit tests should pass.
4. Solves the problem @josephelliot-wk identified.

## FYI

@josephelliot-wk 