### PR TITLE
WP-4435 Add lints and close controllers.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,6 +5,8 @@ linter:
   rules:
     # Error Rules
     - avoid_empty_else
+    - cancel_subscriptions
+    - close_sinks
     - comment_references
     - control_flow_in_finally
     - empty_statements
@@ -17,10 +19,6 @@ linter:
     - throw_in_finally
     - unrelated_type_equality_checks
     - valid_regexps
-
-    # TODO: enable these when addressing memory audit/disposables
-    #- cancel_subscriptions
-    #- close_sinks
 
     # Style Rules
     - always_declare_return_types

--- a/test/serializable_test.dart
+++ b/test/serializable_test.dart
@@ -332,5 +332,13 @@ void main() {
 
       expect(api.removeCalled, isFalse);
     });
+
+    tearDown(() async {
+      await willLoadController.close();
+      await didLoadController.close();
+      await willUnloadController.close();
+      await didUnloadController.close();
+      await bridgeEventController.close();
+    });
   });
 }


### PR DESCRIPTION
# Problem

The `close_sinks` and `cancel_subscriptions` lints were not enabled. When I enabled them, I found a group of tests where `StreamController`s were never closed.

# Solution

- Enable them.
- Close the offending controllers in the tests.

# Testing Suggestion

- [ ] CI passes - tooling only