### PR TITLE
WP-4291 Release w_module 1.2.5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_module
-version: 1.2.3
+version: 1.2.5
 description: Base module classes with a well defined lifecycle for modular Dart applications.
 authors:
   - Workiva Client Platform Team <team-clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [RAP-2057 Fix double unload bug](https://github.com/Workiva/w_module/pull/86)
* [WP-4435 Add lints and close controllers.](https://github.com/Workiva/w_module/pull/87)
* [HY-4995 Clean up resources on failure to load](https://github.com/Workiva/w_module/pull/88)


Requested by: @todbachman-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_module/compare/1.2.4...version-bump-w_module-1-2-5
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_module/compare/1.2.4...1.2.5