### PR TITLE
RAP-2055 Log LifecycleEvents

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -64,7 +64,7 @@ abstract class LifecycleModule extends SimpleModule
   StreamController<LifecycleModule> _didUnloadController;
   final Disposable _disposableProxy = new Disposable();
   Logger _logger;
-  String _name = 'Module';
+  String _name;
   LifecycleState _previousState;
   LifecycleState _state = LifecycleState.instantiated;
   Completer<Null> _transition;
@@ -103,12 +103,28 @@ abstract class LifecycleModule extends SimpleModule
       _didResumeController = new StreamController<LifecycleModule>.broadcast()
     ].forEach(manageStreamController);
 
-    _logger = new Logger('w_module');
+    _logger = new Logger('$name');
+    <
+        String,
+        Stream>{
+      'didLoad': didLoad,
+      'didLoadChildModule': didLoadChildModule,
+      'didResume': didResume,
+      'didSuspend': didSuspend,
+      'didUnload': didUnload,
+      'didUnloadChildModule': didUnloadChildModule,
+      'willLoad': willLoad,
+      'willLoadChildModule': willLoadChildModule,
+      'willResume': willResume,
+      'willSuspend': willSuspend,
+      'willUnload': willUnload,
+      'willUnloadChildModule': willUnloadChildModule,
+    }.forEach(_logLifecycleEvents);
   }
 
   /// Name of the module for identification in exceptions and debug messages.
   // ignore: unnecessary_getters_setters
-  String get name => _name;
+  String get name => _name ?? '$runtimeType';
 
   /// Deprecated: the module name should be defined by overriding the getter in
   /// a subclass and it should not be mutable.
@@ -659,6 +675,14 @@ abstract class LifecycleModule extends SimpleModule
       _didLoadController.addError(error, stackTrace);
       rethrow;
     }
+  }
+
+  /// A utility to logging LifecycleModule lifecycle events
+  void _logLifecycleEvents(
+      String logLabel, Stream<dynamic> lifecycleEventStream) {
+    manageStreamSubscription(lifecycleEventStream.listen(
+        (_) => _logger.fine(logLabel),
+        onError: (error) => _logger.warning('$logLabel error: $error')));
   }
 
   /// Handles a child [LifecycleModule]'s [didUnload] event.

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -32,6 +32,7 @@ class MockStreamSubscription extends Mock implements StreamSubscription<Null> {}
 class TestLifecycleModule extends LifecycleModule {
   Iterable<StreamSubscription<LifecycleModule>> _eventListStreamSubscriptions;
   bool _managedDisposerWasCalled = false;
+  String _name;
 
   final Disposable managedDisposable;
   final StreamController<Null> managedStreamController;
@@ -45,18 +46,22 @@ class TestLifecycleModule extends LifecycleModule {
   Error onWillLoadChildModuleError;
   Error onWillUnloadChildModuleError;
 
-  @override
-  final String name;
-
   // mock data to be used for test validation
   List<String> eventList;
   bool mockShouldUnload;
 
-  TestLifecycleModule({String name})
+  factory TestLifecycleModule() {
+    return new TestLifecycleModule.withModuleName('TestLifecycleMethod');
+  }
+
+  factory TestLifecycleModule.withModuleName(String name) {
+    return new TestLifecycleModule._(name);
+  }
+
+  TestLifecycleModule._(this._name)
       : managedDisposable = new Disposable(),
         managedStreamController = new StreamController<Null>(),
-        managedStreamSubscription = new MockStreamSubscription(),
-        this.name = name {
+        managedStreamSubscription = new MockStreamSubscription() {
     // init test validation data
     eventList = [];
     mockShouldUnload = true;
@@ -101,6 +106,9 @@ class TestLifecycleModule extends LifecycleModule {
   }
 
   bool get managedDisposerWasCalled => _managedDisposerWasCalled;
+
+  @override
+  String get name => _name;
 
   // Overriding without re-applying the @protected annotation allows us to call
   // loadChildModule in our tests below.
@@ -949,8 +957,10 @@ void main() {
     TestLifecycleModule parentModule;
 
     setUp(() async {
-      parentModule = new TestLifecycleModule(name: 'parent');
-      childModule = new TestLifecycleModule(name: 'child');
+      parentModule =
+          new TestLifecycleModule.withModuleName('Parent-TestLifecycleModule');
+      childModule =
+          new TestLifecycleModule.withModuleName('Child-TestLifecycleModule');
       await parentModule.load();
     });
 
@@ -982,22 +992,22 @@ void main() {
               logRecord(
                 level: Level.FINE,
                 message: equals('willLoadChildModule'),
-                loggerName: equals('parent'),
+                loggerName: equals(parentModule.name),
               ),
               logRecord(
                 level: Level.FINE,
                 message: equals('willLoad'),
-                loggerName: equals('child'),
+                loggerName: equals(childModule.name),
               ),
               logRecord(
                 level: Level.FINE,
                 message: equals('didLoad'),
-                loggerName: equals('child'),
+                loggerName: equals(childModule.name),
               ),
               logRecord(
                 level: Level.FINE,
                 message: equals('didLoadChildModule'),
-                loggerName: equals('parent'),
+                loggerName: equals(parentModule.name),
               ),
             ]));
 
@@ -1215,27 +1225,27 @@ void main() {
               logRecord(
                 level: Level.FINE,
                 message: equals('willUnload'),
-                loggerName: equals('parent'),
+                loggerName: equals(parentModule.name),
               ),
               logRecord(
                 level: Level.FINE,
                 message: equals('willUnload'),
-                loggerName: equals('child'),
+                loggerName: equals(childModule.name),
               ),
               logRecord(
                 level: Level.FINE,
                 message: equals('willUnloadChildModule'),
-                loggerName: equals('parent'),
+                loggerName: equals(parentModule.name),
               ),
               logRecord(
                 level: Level.FINE,
                 message: equals('didUnload'),
-                loggerName: equals('child'),
+                loggerName: equals(childModule.name),
               ),
               logRecord(
                 level: Level.FINE,
                 message: equals('didUnloadChildModule'),
-                loggerName: equals('parent'),
+                loggerName: equals(parentModule.name),
               ),
             ]));
 

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -32,7 +32,6 @@ class MockStreamSubscription extends Mock implements StreamSubscription<Null> {}
 class TestLifecycleModule extends LifecycleModule {
   Iterable<StreamSubscription<LifecycleModule>> _eventListStreamSubscriptions;
   bool _managedDisposerWasCalled = false;
-  String _name;
 
   final Disposable managedDisposable;
   final StreamController<Null> managedStreamController;
@@ -46,22 +45,18 @@ class TestLifecycleModule extends LifecycleModule {
   Error onWillLoadChildModuleError;
   Error onWillUnloadChildModuleError;
 
+  @override
+  final String name;
+
   // mock data to be used for test validation
   List<String> eventList;
   bool mockShouldUnload;
 
-  factory TestLifecycleModule() {
-    return new TestLifecycleModule.withModuleName('TestLifecycleMethod');
-  }
-
-  factory TestLifecycleModule.withModuleName(String name) {
-    return new TestLifecycleModule._(name);
-  }
-
-  TestLifecycleModule._(this._name)
+  TestLifecycleModule({String name})
       : managedDisposable = new Disposable(),
         managedStreamController = new StreamController<Null>(),
-        managedStreamSubscription = new MockStreamSubscription() {
+        managedStreamSubscription = new MockStreamSubscription(),
+        name = name ?? 'TestLifecycleModule' {
     // init test validation data
     eventList = [];
     mockShouldUnload = true;
@@ -106,9 +101,6 @@ class TestLifecycleModule extends LifecycleModule {
   }
 
   bool get managedDisposerWasCalled => _managedDisposerWasCalled;
-
-  @override
-  String get name => _name;
 
   // Overriding without re-applying the @protected annotation allows us to call
   // loadChildModule in our tests below.
@@ -957,10 +949,8 @@ void main() {
     TestLifecycleModule parentModule;
 
     setUp(() async {
-      parentModule =
-          new TestLifecycleModule.withModuleName('Parent-TestLifecycleModule');
-      childModule =
-          new TestLifecycleModule.withModuleName('Child-TestLifecycleModule');
+      parentModule = new TestLifecycleModule(name: 'parent');
+      childModule = new TestLifecycleModule(name: 'child');
       await parentModule.load();
     });
 

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -283,9 +283,12 @@ Future<Null> executeStateTransition(
 
 void main() {
   Logger.root.level = Level.ALL;
+  var messagePattern = new RegExp(r'^did|^will');
 
   LogRecord lastLogMessage;
-  Logger.root.onRecord.listen((LogRecord message) {
+  Logger.root.onRecord
+      .where((LogRecord r) => !messagePattern.hasMatch(r.message))
+      .listen((LogRecord message) {
     lastLogMessage = message;
   });
 

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -23,6 +23,8 @@ import 'package:w_common/disposable.dart';
 
 import 'package:w_module/src/lifecycle_module.dart';
 
+import 'utils.dart';
+
 const String shouldUnloadError = 'Mock shouldUnload false message';
 
 class MockStreamSubscription extends Mock implements StreamSubscription<Null> {}
@@ -50,11 +52,11 @@ class TestLifecycleModule extends LifecycleModule {
   List<String> eventList;
   bool mockShouldUnload;
 
-  TestLifecycleModule()
+  TestLifecycleModule({String name})
       : managedDisposable = new Disposable(),
         managedStreamController = new StreamController<Null>(),
         managedStreamSubscription = new MockStreamSubscription(),
-        name = 'TestLifecycleModule' {
+        this.name = name {
     // init test validation data
     eventList = [];
     mockShouldUnload = true;
@@ -283,22 +285,13 @@ Future<Null> executeStateTransition(
 
 void main() {
   Logger.root.level = Level.ALL;
-  var messagePattern = new RegExp(r'^did|^will');
-
-  LogRecord lastLogMessage;
-  Logger.root.onRecord
-      .where((LogRecord r) => !messagePattern.hasMatch(r.message))
-      .listen((LogRecord message) {
-    lastLogMessage = message;
-  });
-
   final StateError testError = new StateError('You should have expected this');
 
   group('LifecycleModule', () {
     TestLifecycleModule module;
-    setUp(() {
+
+    setUp(() async {
       module = new TestLifecycleModule();
-      lastLogMessage = null;
     });
 
     tearDown(() async {
@@ -330,6 +323,17 @@ void main() {
         expect(module.isLoading, isTrue);
         await future;
         expect(module.isLoading, isFalse);
+      });
+
+      test('should emit lifecycle log events', () async {
+        expect(
+            Logger.root.onRecord,
+            emitsInOrder([
+              logRecord(level: Level.FINE, message: equals('willLoad')),
+              logRecord(level: Level.FINE, message: equals('didLoad')),
+            ]));
+
+        await module.load();
       });
 
       group('with an onLoad that throws', () {
@@ -391,18 +395,22 @@ void main() {
 
       test('should warn if it is already loading', () async {
         await gotoState(module, LifecycleState.loading);
-        expect(lastLogMessage, isNull);
+        expect(
+            Logger.root.onRecord,
+            emits(
+                logRecord(level: Level.WARNING, message: contains('loading'))));
+
         await module.load();
-        expect(lastLogMessage.message, contains('loading'));
-        expect(lastLogMessage.level, equals(Level.WARNING));
       });
 
       test('should warn if it was already loaded', () async {
         await module.load();
-        expect(lastLogMessage, isNull);
+        expect(
+            Logger.root.onRecord,
+            emits(
+                logRecord(level: Level.WARNING, message: contains('loaded'))));
+
         await module.load();
-        expect(lastLogMessage.message, contains('loaded'));
-        expect(lastLogMessage.level, equals(Level.WARNING));
       });
 
       testInvalidTransitions(LifecycleState.loading, [
@@ -457,6 +465,18 @@ void main() {
             module.eventList,
             ['willResume', 'onResume', 'didResume']
               ..addAll(expectedUnloadEvents));
+      });
+
+      test('should emit lifecycle log events', () async {
+        await gotoState(module, LifecycleState.loaded);
+        expect(
+            Logger.root.onRecord,
+            emitsInOrder([
+              logRecord(level: Level.FINE, message: equals('willUnload')),
+              logRecord(level: Level.FINE, message: equals('didUnload')),
+            ]));
+
+        await module.unload();
       });
 
       group('with an onUnload that throws', () {
@@ -548,18 +568,20 @@ void main() {
 
       test('should warn if it is already unloading', () async {
         await gotoState(module, LifecycleState.unloading);
-        expect(lastLogMessage, isNull);
+        expect(
+            Logger.root.onRecord,
+            emits(logRecord(
+                level: Level.WARNING, message: contains('unloading'))));
         await module.unload();
-        expect(lastLogMessage.message, contains('unloading'));
-        expect(lastLogMessage.level, equals(Level.WARNING));
       });
 
       test('should warn if it was already unloaded', () async {
         await gotoState(module, LifecycleState.unloaded);
-        expect(lastLogMessage, isNull);
+        expect(
+            Logger.root.onRecord,
+            emits(logRecord(
+                level: Level.WARNING, message: contains('unloaded'))));
         await module.unload();
-        expect(lastLogMessage.message, contains('unloaded'));
-        expect(lastLogMessage.level, equals(Level.WARNING));
       });
 
       test('should throw an exception if shouldUnload completes false',
@@ -657,6 +679,17 @@ void main() {
             ['willResume', 'onResume', 'didResume']
               ..addAll(expectedSuspendEvents));
       });
+      test('should emit lifecycle log events', () async {
+        await gotoState(module, LifecycleState.loaded);
+        expect(
+            Logger.root.onRecord,
+            emitsInOrder([
+              logRecord(level: Level.FINE, message: equals('willSuspend')),
+              logRecord(level: Level.FINE, message: equals('didSuspend')),
+            ]));
+
+        await module.suspend();
+      });
 
       group('with an onSuspend that throws', () {
         setUp(() async {
@@ -733,18 +766,22 @@ void main() {
 
       test('should warn if it is already suspending', () async {
         await gotoState(module, LifecycleState.suspending);
-        expect(lastLogMessage, isNull);
+        expect(
+            Logger.root.onRecord,
+            emits(logRecord(
+                level: Level.WARNING, message: contains('suspending'))));
+
         await module.suspend();
-        expect(lastLogMessage.message, contains('suspending'));
-        expect(lastLogMessage.level, equals(Level.WARNING));
       });
 
       test('should warn if it is already suspended', () async {
         await gotoState(module, LifecycleState.suspended);
-        expect(lastLogMessage, isNull);
+        expect(
+            Logger.root.onRecord,
+            emits(logRecord(
+                level: Level.WARNING, message: contains('suspended'))));
+
         await module.suspend();
-        expect(lastLogMessage.message, contains('suspended'));
-        expect(lastLogMessage.level, equals(Level.WARNING));
       });
 
       testInvalidTransitions(LifecycleState.suspending, [
@@ -772,6 +809,18 @@ void main() {
             module.eventList,
             ['willSuspend', 'onSuspend', 'didSuspend']
               ..addAll(expectedResumeEvents));
+      });
+
+      test('should emit lifecycle log events', () async {
+        await gotoState(module, LifecycleState.suspended);
+        expect(
+            Logger.root.onRecord,
+            emitsInOrder([
+              logRecord(level: Level.FINE, message: equals('willResume')),
+              logRecord(level: Level.FINE, message: equals('didResume')),
+            ]));
+
+        await module.resume();
       });
 
       group('with an onResume that throws', () {
@@ -851,18 +900,23 @@ void main() {
         await gotoState(module, LifecycleState.suspended);
         // ignore: unawaited_futures
         module.resume();
-        expect(lastLogMessage, isNull);
+
+        expect(
+            Logger.root.onRecord,
+            emits(logRecord(
+                level: Level.WARNING, message: contains('resuming'))));
+
         await module.resume();
-        expect(lastLogMessage.message, contains('resuming'));
-        expect(lastLogMessage.level, equals(Level.WARNING));
       });
 
       test('should warn if it is already loaded', () async {
         await gotoState(module, LifecycleState.loaded);
-        expect(lastLogMessage, isNull);
+        expect(
+            Logger.root.onRecord,
+            emits(
+                logRecord(level: Level.WARNING, message: contains('loaded'))));
+
         await module.resume();
-        expect(lastLogMessage.message, contains('loaded'));
-        expect(lastLogMessage.level, equals(Level.WARNING));
       });
 
       testInvalidTransitions(LifecycleState.resuming, [
@@ -891,12 +945,12 @@ void main() {
   }, timeout: new Timeout(new Duration(seconds: 2)));
 
   group('LifecycleModule with children', () {
-    TestLifecycleModule parentModule;
     TestLifecycleModule childModule;
+    TestLifecycleModule parentModule;
 
     setUp(() async {
-      parentModule = new TestLifecycleModule();
-      childModule = new TestLifecycleModule();
+      parentModule = new TestLifecycleModule(name: 'parent');
+      childModule = new TestLifecycleModule(name: 'child');
       await parentModule.load();
     });
 
@@ -919,6 +973,35 @@ void main() {
             ]));
         expect(
             childModule.eventList, equals(['willLoad', 'onLoad', 'didLoad']));
+      });
+
+      test('should emit lifecycle log events', () async {
+        expect(
+            Logger.root.onRecord,
+            emitsInOrder([
+              logRecord(
+                level: Level.FINE,
+                message: equals('willLoadChildModule'),
+                loggerName: equals('parent'),
+              ),
+              logRecord(
+                level: Level.FINE,
+                message: equals('willLoad'),
+                loggerName: equals('child'),
+              ),
+              logRecord(
+                level: Level.FINE,
+                message: equals('didLoad'),
+                loggerName: equals('child'),
+              ),
+              logRecord(
+                level: Level.FINE,
+                message: equals('didLoadChildModule'),
+                loggerName: equals('parent'),
+              ),
+            ]));
+
+        await parentModule.loadChildModule(childModule);
       });
 
       group('with a child with an onLoad that throws', () {
@@ -1122,6 +1205,41 @@ void main() {
               'onUnload',
               'didUnload'
             ]));
+      });
+
+      test('should emit lifecycle log events', () async {
+        await parentModule.loadChildModule(childModule);
+        expect(
+            Logger.root.onRecord,
+            emitsInOrder([
+              logRecord(
+                level: Level.FINE,
+                message: equals('willUnload'),
+                loggerName: equals('parent'),
+              ),
+              logRecord(
+                level: Level.FINE,
+                message: equals('willUnload'),
+                loggerName: equals('child'),
+              ),
+              logRecord(
+                level: Level.FINE,
+                message: equals('willUnloadChildModule'),
+                loggerName: equals('parent'),
+              ),
+              logRecord(
+                level: Level.FINE,
+                message: equals('didUnload'),
+                loggerName: equals('child'),
+              ),
+              logRecord(
+                level: Level.FINE,
+                message: equals('didUnloadChildModule'),
+                loggerName: equals('parent'),
+              ),
+            ]));
+
+        await parentModule.unload();
       });
 
       group('with a child with an onUnload that throws', () {

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,0 +1,77 @@
+import 'package:logging/logging.dart';
+import 'package:matcher/matcher.dart';
+
+/// Provides a Matcher for [LogRecord].
+///
+/// The [Matcher] only considers provided optional parameters.
+Matcher logRecord({Level level, Matcher message, Matcher loggerName}) {
+  var matchers = [];
+  if (level != null) {
+    matchers.add(new _LogLevelMatcher(level));
+  }
+  if (message != null) {
+    matchers.add(new _LogMessageMatcher(message));
+  }
+  if (loggerName != null) {
+    matchers.add(new _LoggerNameMatcher(loggerName));
+  }
+
+  return allOf(matchers);
+}
+
+class _LogLevelMatcher extends Matcher {
+  final Level _level;
+
+  _LogLevelMatcher(this._level);
+
+  @override
+  Description describe(Description description) =>
+      description.add('with $_level log level');
+
+  @override
+  bool matches(dynamic record, Map matchState) {
+    if (_level == null) {
+      return false;
+    }
+    if (record is LogRecord) {
+      return record.level == _level;
+    }
+    return false;
+  }
+}
+
+class _LogMessageMatcher extends Matcher {
+  final Matcher _messageMatcher;
+
+  _LogMessageMatcher(this._messageMatcher);
+
+  @override
+  Description describe(Description description) =>
+      description.add('log message ').addDescriptionOf(_messageMatcher);
+
+  @override
+  bool matches(dynamic record, Map matchState) {
+    if (record is LogRecord) {
+      return _messageMatcher.matches(record.message, matchState);
+    }
+    return false;
+  }
+}
+
+class _LoggerNameMatcher extends Matcher {
+  final Matcher _nameMatcher;
+
+  _LoggerNameMatcher(this._nameMatcher);
+
+  @override
+  Description describe(Description description) =>
+      description.add('logger name ').addDescriptionOf(_nameMatcher);
+
+  @override
+  bool matches(dynamic item, Map matchState) {
+    if (item is LogRecord) {
+      return _nameMatcher.matches(item.loggerName, matchState);
+    }
+    return false;
+  }
+}

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -30,7 +30,7 @@ Future<Null> main(List<String> args) async {
     'tool/'
   ];
   config.copyLicense.directories = directories;
-  config.format.directories = directories;
+  config.format.paths = directories;
 
   await dev(args);
 }


### PR DESCRIPTION
## Problem

There is no insight into the current lifecycle state for a instance of LifecycleModule. 

## Solution

Emit a log event when a `LifecycleModule` transitions to a new lifecycle state. This provides a consistent and clear indication of what state any given LifecycleModule instance is in.

## Howto QA

- [ ] Ensure CI passes
    - Explicit unit tests were added to confirm behavior
- [ ] Link into an existing project
- [ ] Set the log level to at least FINE
- [ ] Confirm lifecycle state changes are logged

## References
/fya @Workiva/rich-app-platform-pp @Workiva/web-platform-pp 