### PR TITLE
RAP-2139 Ensure dispose is called when onUnload fails.

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -801,9 +801,12 @@ abstract class LifecycleModule extends SimpleModule
       rethrow;
     } catch (error, stackTrace) {
       _didUnloadController.addError(error, stackTrace);
-      await _disposableProxy.dispose();
-      await _postUnloadDisposable.dispose();
-      rethrow;
+      try {
+        await _disposableProxy.dispose();
+      } finally {
+        await _postUnloadDisposable.dispose();
+        rethrow;
+      }
     }
   }
 }

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -801,6 +801,7 @@ abstract class LifecycleModule extends SimpleModule
       rethrow;
     } catch (error, stackTrace) {
       _didUnloadController.addError(error, stackTrace);
+      await _disposableProxy.dispose();
       await _postUnloadDisposable.dispose();
       rethrow;
     }


### PR DESCRIPTION
### Description
<!--
Note whether this is a bug fix, improvement, feature, or tech-debt and explain
the motivation behind this PR.
-->
The call to the internal disposable proxy is made after `onUnload`. If an error is returned by `onUnload`, this dispose call is never made leaking all instances retained by `Disposable`.

### Changes
<!--
Give a high-level overview of the changes included in this PR.
-->
Dispose `_disposableProxy` in the `onUnload` error catch block.

### Semantic Versioning

- [x] **Patch**
  - [x] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API


### Testing/QA

<!-- Include additional steps for testing if necessary. -->
- [ ] CI passes


### Code Review

@Workiva/rich-app-platform-pp