### PR TITLE
RAP-2220 Update Module to the latest DisposableManager interface

### DIFF
--- a/lib/src/events_collection.dart
+++ b/lib/src/events_collection.dart
@@ -50,6 +50,6 @@ class EventsCollection extends Disposable {
   @mustCallSuper
   @protected
   void manageEvent(Event event) {
-    manageDisposer(() => event.close(_key));
+    getManagedDisposer(() => event.close(_key));
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   logging: ^0.11.0
   meta: ^1.0.0
   platform_detect: ^1.1.0
-  w_common: ^1.4.0
+  w_common: ^1.7.2
 
 dev_dependencies:
   browser: ^0.10.0+2


### PR DESCRIPTION
## Issue

`LifecycleModule` supports memory management by proxying to an underlying disposable instead of extending `Disposable` directly. It is currently implementing V3 but the latest version is V5.

## Solution

Update `LifecycleModule` to update the latest version of the disposable manager interface: `DisposableManagerV5`.

## Testing

- [ ] CI passes (tests updated)

> It would be nice if there was a `w_common_tests` package that provided a test suite that exercises classes that implement the `DisposableManager` interfaces so that we could get these verifications for free.

## Code Review
@Workiva/web-platform-pp @Workiva/rich-app-platform-pp 