### PR TITLE
WP-4899 Allow disposal of LifecycleModule prior to load

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -583,6 +583,13 @@ abstract class LifecycleModule extends SimpleModule
               isUnloading ? LifecycleState.unloading : LifecycleState.unloaded);
     }
 
+    if (isInstantiated) {
+      _state = LifecycleState.unloaded;
+      _previousState = null;
+      _transition = null;
+      return _dispose();
+    }
+
     if (!(isLoaded || isLoading || isResuming || isSuspended || isSuspending)) {
       return _buildIllegalTransitionResponse(
           targetState: LifecycleState.unloaded,
@@ -694,6 +701,14 @@ abstract class LifecycleModule extends SimpleModule
     return _transition?.future ?? new Future.value(null);
   }
 
+  Future<Null> _dispose() async {
+    try {
+      await _disposableProxy.dispose();
+    } finally {
+      await _postUnloadDisposable.dispose();
+    }
+  }
+
   Future<Null> _load() async {
     try {
       _willLoadController.add(this);
@@ -796,6 +811,7 @@ abstract class LifecycleModule extends SimpleModule
   }
 
   Future<Null> _unload(Future<Null> pendingTransition) async {
+    var unloadWasCanceled = false;
     try {
       if (pendingTransition != null) {
         await pendingTransition;
@@ -818,23 +834,23 @@ abstract class LifecycleModule extends SimpleModule
       _childModules.clear();
       await Future.wait(childUnloadFutures);
       await onUnload();
-      await _disposableProxy.dispose();
       if (_state == LifecycleState.unloading) {
         _state = LifecycleState.unloaded;
         _previousState = null;
         _transition = null;
       }
       _didUnloadController.add(this);
-      await _postUnloadDisposable.dispose();
     } on ModuleUnloadCanceledException catch (error, _) {
+      unloadWasCanceled = true;
       rethrow;
     } catch (error, stackTrace) {
       _didUnloadController.addError(error, stackTrace);
-      try {
-        await _disposableProxy.dispose();
-      } finally {
-        await _postUnloadDisposable.dispose();
-        rethrow;
+      rethrow;
+    } finally {
+      // Unless the unload was canceled (via shouldUnload), force the disposal
+      // to ensure that as much as possible is cleaned up.
+      if (!unloadWasCanceled) {
+        await _dispose();
       }
     }
   }


### PR DESCRIPTION
## Issue

It is possible that a `LifecycleModule` may have some things that need to be managed immediately after construction (i.e. before load). Currently, you cannot dispose/unload a module that has not been loaded, which makes it impossible to clean up these things.

## Solution

Allow `unload()` to proceed if the module is still in the `isInstantiated` state (not loaded) by short-circuiting directly to disposal.

## Testing

- [ ] CI passes (still need to add tests)

## Code Review

@Workiva/web-platform-pp @Workiva/rich-app-platform-pp 