### PR TITLE
WP-4910 Update LifecycleModule to DisposableManagerV6

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -52,7 +52,7 @@ enum LifecycleState {
 /// Intended to be extended by most base module classes in order to provide a
 /// unified lifecycle API.
 abstract class LifecycleModule extends SimpleModule
-    implements DisposableManagerV5 {
+    implements DisposableManagerV6 {
   List<LifecycleModule> _childModules = [];
   StreamController<LifecycleModule> _didLoadChildModuleController;
   StreamController<LifecycleModule> _didLoadController;
@@ -382,6 +382,11 @@ abstract class LifecycleModule extends SimpleModule
 
     return completer.future;
   }
+
+  /// Automatically dispose another object when this object is disposed.
+  @override
+  Disposable manageAndReturnDisposable(Disposable disposable) =>
+      _disposableProxy.manageAndReturnDisposable(disposable);
 
   /// Ensures a given [Completer] is completed when the module is unloaded.
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   logging: ^0.11.0
   meta: ^1.0.0
   platform_detect: ^1.1.0
-  w_common: ^1.7.2
+  w_common: ^1.8.0
 
 dev_dependencies:
   browser: ^0.10.0+2

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -35,6 +35,7 @@ class TestLifecycleModule extends LifecycleModule {
   bool _getManagedDisposerWasCalled = false;
 
   final Disposable managedDisposable;
+  Disposable managedDisposable2;
   ManagedDisposer managedDisposer;
   final StreamController<Null> managedStreamController;
   final MockStreamSubscription managedStreamSubscription;
@@ -68,6 +69,7 @@ class TestLifecycleModule extends LifecycleModule {
       _getManagedDisposerWasCalled = true;
     });
     manageDisposable(managedDisposable);
+    managedDisposable2 = manageAndReturnDisposable(new Disposable());
     manageDisposer(() {
       _managedDisposerWasCalled = true;
     });
@@ -645,6 +647,7 @@ void main() {
       test('should dispose managed disposables', () async {
         await module.load();
         expect(module.managedDisposable.isDisposed, isFalse);
+        expect(module.managedDisposable2.isDisposed, isFalse);
         expect(module.managedDisposerWasCalled, isFalse);
         expect(module.getManagedDisposerWasCalled, isFalse);
         expect(module.managedStreamController.isClosed, isFalse);
@@ -657,6 +660,7 @@ void main() {
 
         await module.unload();
         expect(module.managedDisposable.isDisposed, isTrue);
+        expect(module.managedDisposable2.isDisposed, isTrue);
         expect(module.managedDisposerWasCalled, isTrue);
         expect(module.getManagedDisposerWasCalled, isTrue);
         expect(module.managedStreamController.isClosed, isTrue);


### PR DESCRIPTION
## Description

There is a new version of the `DisposableManager` interface that we can update `LifecycleModule` to.

## Testing

- [ ] CI Passes (tests added)

## Code Review
@Workiva/web-platform-pp @Workiva/rich-app-platform-pp 