### PR TITLE
WP-4919 Unblock transition errors

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -464,13 +464,20 @@ abstract class LifecycleModule extends SimpleModule
             LifecycleState.resuming
           ]);
     }
-    var previousTransition = _transition?.future;
+    Future<Null> previousTransition;
+    if (_transition != null && !_transition.isCompleted) {
+      previousTransition = _transition.future;
+    }
     _transition = new Completer<Null>();
+    var backupState = _state;
     _state = LifecycleState.suspending;
 
     _suspend(previousTransition)
         .then(_transition.complete)
-        .catchError(_transition.completeError);
+        .catchError((e, trace) {
+      _transition.completeError(e, trace);
+      _state = backupState;
+    });
     return _transition.future;
   }
 
@@ -511,13 +518,21 @@ abstract class LifecycleModule extends SimpleModule
           allowedStates: [LifecycleState.suspended, LifecycleState.suspending]);
     }
 
-    var pendingTransition = _transition?.future;
+    Future<Null> previousTransition;
+    if (_transition != null && !_transition.isCompleted) {
+      previousTransition = _transition.future;
+    }
+
+    var backupState = _state;
     _state = LifecycleState.resuming;
     _transition = new Completer<Null>();
 
-    _resume(pendingTransition)
+    _resume(previousTransition)
         .then(_transition.complete)
-        .catchError(_transition.completeError);
+        .catchError((e, trace) {
+      _transition.completeError(e, trace);
+      _state = backupState;
+    });
 
     return _transition.future;
   }
@@ -597,12 +612,16 @@ abstract class LifecycleModule extends SimpleModule
           ]);
     }
 
-    var pendingTransition = _transition?.future;
+    Future<Null> previousTransition;
+    if (_transition != null && !_transition.isCompleted) {
+      previousTransition = _transition.future;
+    }
+
     _previousState = _state;
     _state = LifecycleState.unloading;
     _transition = new Completer<Null>();
 
-    _unload(pendingTransition)
+    _unload(previousTransition)
         .then(_transition.complete)
         .catchError(_transition.completeError);
 

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -664,9 +664,6 @@ void main() {
         controller.add(null);
         await controller.close();
       });
-
-      testInvalidTransitions(
-          LifecycleState.unloading, [LifecycleState.instantiated]);
     });
 
     group('suspend', () {


### PR DESCRIPTION
# Problem

If a module has an uncaught exception during an error, it is impossible to unload even after #95 is consumed to permit unloading from instantiated state.

# Solution

Specifically revert state back if a transition fails and clear the `_transition` completer so that the error that caused the transition to fail is not repeatedly consumed on subsequent `unload()` calls.

# Testing Suggestion

TBA