### PR TITLE
WP-4849 Release w_module 1.4.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_module
-version: 1.3.0
+version: 1.4.0
 description: Base module classes with a well defined lifecycle for modular Dart applications.
 authors:
   - Workiva Client Platform Team <team-clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4910 Update LifecycleModule to DisposableManagerV6](https://github.com/Workiva/w_module/pull/96)


Requested by: @jayudey-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_module/compare/1.3.0...version-bump-w_module-1-4-0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_module/compare/1.3.0...1.4.0