### PR TITLE
WP-4883 Ensure Examples and Tests run w/ DDC

### DIFF
--- a/example/panel/index.html
+++ b/example/panel/index.html
@@ -24,7 +24,7 @@ limitations under the License.
     <body>
         <div id="panel-container"></div>
 
-        <script src="packages/react/react.js"></script>
+        <script src="packages/react/react_with_react_dom_prod.js"></script>
         <script type="application/dart" src="panel_app.dart"></script>
         <script src="packages/browser/dart.js"></script>
     </body>

--- a/example/panel/panel_app.dart
+++ b/example/panel/panel_app.dart
@@ -19,7 +19,7 @@ import 'dart:html';
 import 'dart:js' as js;
 
 import 'package:platform_detect/platform_detect.dart';
-import 'package:react/react.dart' as react;
+import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart' as react_client;
 import 'package:w_module/w_module.dart' hide Event;
 
@@ -52,5 +52,5 @@ Future<Null> main() async {
   });
 
   // render the app into the browser
-  react.render(panelModule.components.content(), container);
+  react_dom.render(panelModule.components.content(), container);
 }

--- a/example/random_color/index.html
+++ b/example/random_color/index.html
@@ -36,7 +36,7 @@ limitations under the License.
             <div id="content-container" style="border: 5px dashed red"></div>
         </div>
 
-        <script src="packages/react/react_prod.js"></script>
+        <script src="packages/react/react_with_react_dom_prod.js"></script>
         <script type="application/dart" src="random_color.dart"></script>
         <script src="packages/browser/dart.js"></script>
     </body>

--- a/example/random_color/random_color.dart
+++ b/example/random_color/random_color.dart
@@ -19,6 +19,7 @@ import 'dart:html' as html;
 import 'dart:math';
 
 import 'package:react/react.dart' as react;
+import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart' as react_client;
 
 import 'package:w_flux/w_flux.dart';
@@ -31,7 +32,7 @@ Future<Null> main() async {
 
   // render the module's UI component
   react_client.setClientConfiguration();
-  react.render(randomColorModule.components.content(),
+  react_dom.render(randomColorModule.components.content(),
       html.querySelector('#content-container'));
 
   // exercise the module's API via some simple button clicks

--- a/lib/src/serializable.dart
+++ b/lib/src/serializable.dart
@@ -70,14 +70,6 @@ class _ModuleRegistration extends Object with Disposable {
   final SerializableModule module;
 
   _ModuleRegistration(this.module);
-
-  @override
-  StreamSubscription<T> listenToStream<T>(
-      Stream<T> stream, void onData(T event),
-      {Function onError, void onDone(), bool cancelOnError}) {
-    return super.listenToStream(stream, onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
-  }
 }
 
 class SerializableBus {

--- a/lib/src/serializable.dart
+++ b/lib/src/serializable.dart
@@ -36,8 +36,11 @@ abstract class Bridge<T> extends Object with Disposable {
   void broadcastSerializedEvent(Map event);
   void handleSerializedApiCall(T apiCall);
 
-  void _manageStreamSubscription(StreamSubscription subscription) {
-    super.manageStreamSubscription(subscription);
+  StreamSubscription<T> _listenToStream<T>(
+      Stream<T> stream, void onData(T event),
+      {Function onError, void onDone(), bool cancelOnError}) {
+    return super.listenToStream(stream, onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 }
 
@@ -69,8 +72,11 @@ class _ModuleRegistration extends Object with Disposable {
   _ModuleRegistration(this.module);
 
   @override
-  void manageStreamSubscription(StreamSubscription subscription) {
-    super.manageStreamSubscription(subscription);
+  StreamSubscription<T> listenToStream<T>(
+      Stream<T> stream, void onData(T event),
+      {Function onError, void onDone(), bool cancelOnError}) {
+    return super.listenToStream(stream, onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 }
 
@@ -88,8 +94,7 @@ class SerializableBus {
 
     if (bridge != null) {
       _bridge = bridge;
-      _bridge?._manageStreamSubscription(
-          bridge.apiCallReceived.listen(_handleApiCall));
+      _bridge._listenToStream(bridge.apiCallReceived, _handleApiCall);
     } else {
       _logger.warning('Attempt to set bridge to null');
     }
@@ -138,6 +143,7 @@ class SerializableBus {
   void _deserializeAndCall(
       SerializableModule module, String method, List data) {
     InstanceMirror apiMirror = reflect(module.api);
+    List reflectedData = new List(data.length);
 
     if (apiMirror == null) {
       _logger.warning(
@@ -171,7 +177,7 @@ class SerializableBus {
         try {
           var instance = paramClassMirror
               .newInstance(new Symbol('fromJson'), [data[i]]).reflectee;
-          data[i] = instance;
+          reflectedData[i] = instance;
         } on NoSuchMethodError {
           _logger.warning(
               '${paramClassMirror.simpleName.toString()} does not implement fromJson named constructor');
@@ -181,7 +187,7 @@ class SerializableBus {
     }
 
     try {
-      apiMirror.invoke(new Symbol(method), data);
+      apiMirror.invoke(new Symbol(method), reflectedData);
     } catch (e) {
       _logger.severe(
           'Unable to call $method on ${module.serializableKey} w_module, ${e.toString()}');
@@ -192,8 +198,10 @@ class SerializableBus {
     if (registration.module.events != null) {
       for (var event in registration.module.events.allEvents) {
         if (event is SerializableEvent) {
-          registration.manageStreamSubscription(event.listen((payload) =>
-              _sendEvent(registration.module, event.eventKey, payload)));
+          registration.listenToStream(
+              event,
+              (payload) =>
+                  _sendEvent(registration.module, event.eventKey, payload));
         }
       }
     } else {
@@ -203,20 +211,18 @@ class SerializableBus {
   }
 
   void _registerForLifecycleEvents(_ModuleRegistration registration) {
-    registration
-        .manageStreamSubscription(registration.module.willLoad.listen((_) {
+    registration.listenToStream(registration.module.willLoad, (_) {
       _registerForAllEvents(registration);
       _sendEvent(registration.module, 'willLoad', null);
-    }));
-    registration.manageStreamSubscription(registration.module.didLoad
-        .listen((_) => _sendEvent(registration.module, 'didLoad', null)));
-    registration.manageStreamSubscription(registration.module.willUnload
-        .listen((_) => _sendEvent(registration.module, 'willUnload', null)));
-    registration
-        .manageStreamSubscription(registration.module.didUnload.listen((_) {
+    });
+    registration.listenToStream(registration.module.didLoad,
+        (_) => _sendEvent(registration.module, 'didLoad', null));
+    registration.listenToStream(registration.module.willUnload,
+        (_) => _sendEvent(registration.module, 'willUnload', null));
+    registration.listenToStream(registration.module.didUnload, (_) {
       _sendEvent(registration.module, 'didUnload', null);
       deregisterModule(registration.module);
-    }));
+    });
   }
 
   void _sendEvent(SerializableModule module, String eventKey, Object data) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,13 +19,17 @@ dependencies:
 dev_dependencies:
   browser: ^0.10.0+2
   coverage: ^0.7.3
-  dart_dev: ^1.7.2
+  dart_dev: ^1.8.0
   dart_style: ^0.2.16
   dartdoc: ^0.9.0
   mockito: ^1.0.1
-  react: '>=0.5.0 <0.8.0'
+  react: ^3.0.0
   test: ^0.12.0
-  w_flux: ^1.0.0
+  w_flux: '>=1.0.0 <3.0.0'
 
 environment:
   sdk: '>=1.9.0 <2.0.0'
+
+transformers:
+  - test/pub_serve:
+      $include: test/**_test{.*,}dart

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,11 +1,12 @@
 project: dart
 language: dart
 
-# dart 1.19.1
-runner_image: drydock-prod.workiva.org/workiva/smithy-runner-generator:92530
+# dart 1.24.2
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:203768
 
 script:
-  - pub get
+  - pub get --packages-dir
+  - xvfb-run -s '-screen 0 1024x768x24' pub run dart_dev test --pub-serve --web-compiler=dartdevc -p chrome -p vm
 
 artifacts:
   build:


### PR DESCRIPTION
### Description
w_module has not been updated to run with DDC

### Changes
Update w_module to be DDC compliant!
- Updated version constraints on `w_flux` and `react` to pull in DDC compliant verions
- Updated examples to compile with DDC
- Addressed test failures when using DDC
- Addressed deprecations

### Testing/QA
- [ ] CI Passes
- [ ] Examples run w/ DDC
  - [ ] `pub serve example --web-compiler=dartdevc`, then navigate to localhost:8080 in chrome
- [ ] Tests run w/ DDC
  - [ ] `pub run dart_dev test --pub-serve --web-compiler=dartdevc -p chrome -p vm` 

### Review
@Workiva/web-platform-pp 
