### PR TITLE
WP-4919 unblock transition errors

### DIFF
--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -668,9 +668,6 @@ void main() {
         controller.add(null);
         await controller.close();
       });
-
-      testInvalidTransitions(
-          LifecycleState.unloading, [LifecycleState.instantiated]);
     });
 
     group('suspend', () {


### PR DESCRIPTION
# Problem

If a module has an uncaught exception during an error, it is impossible to unload because it is in the middle of a transition.

# Solution

Specifically revert state back if a transition fails and clear the `_transition` completer so that the error that caused the transition to fail is not repeatedly consumed on subsequent `unload()` calls.

# Testing Suggestion

TBA