### PR TITLE
WP-4919 Unblock mid-transition states

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -897,6 +897,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       // not explicitly cancel the unload), emit the unload failure event and
       // then rethrow the exception so that the caller (either unload() or
       // onWillDispose()) can handle it.
+      _state = LifecycleState.unloaded;
       _didUnloadController.addError(error, stackTrace);
       rethrow;
     }

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -321,11 +321,19 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
     }
 
     _state = LifecycleState.loading;
-    _transition = new Completer<Null>();
 
-    _load().then(_transition.complete).catchError(_transition.completeError);
+    // Keep track of this load's completer
+    final transition = new Completer<Null>();
 
-    return _transition.future;
+    // because this one can get overwritten
+    _transition = transition;
+
+    _load().then(transition.complete).catchError((error, trace) {
+      transition.completeError(error, trace);
+      _state = LifecycleState.loaded;
+    });
+
+    return transition.future;
   }
 
   /// Public method to async load a child module and register it
@@ -454,13 +462,21 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
             LifecycleState.resuming
           ]);
     }
-    var previousTransition = _transition?.future;
+
+    Future pendingTransition;
+    if (_transition != null && !_transition.isCompleted) {
+      pendingTransition = _transition.future;
+    }
+
     _transition = new Completer<Null>();
     _state = LifecycleState.suspending;
 
-    _suspend(previousTransition)
+    _suspend(pendingTransition)
         .then(_transition.complete)
-        .catchError(_transition.completeError);
+        .catchError((error, trace) {
+      _transition.completeError(error, trace);
+      _state = LifecycleState.loaded;
+    });
     return _transition.future;
   }
 
@@ -505,13 +521,20 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
           allowedStates: [LifecycleState.suspended, LifecycleState.suspending]);
     }
 
-    var pendingTransition = _transition?.future;
+    Future pendingTransition;
+    if (_transition != null && !_transition.isCompleted) {
+      pendingTransition = _transition.future;
+    }
+
     _state = LifecycleState.resuming;
     _transition = new Completer<Null>();
 
     _resume(pendingTransition)
         .then(_transition.complete)
-        .catchError(_transition.completeError);
+        .catchError((error, trace) {
+      _transition.completeError(error, trace);
+      _state = LifecycleState.suspended;
+    });
 
     return _transition.future;
   }
@@ -596,7 +619,11 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
           ]);
     }
 
-    var pendingTransition = _transition?.future;
+    Future pendingTransition;
+    if (_transition != null && !_transition.isCompleted) {
+      pendingTransition = _transition.future;
+    }
+
     _previousState = _state;
     _state = LifecycleState.unloading;
     _transition = new Completer<Null>();
@@ -683,7 +710,10 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       if (isUnloading) {
         unloadingTransitionFuture = _transition.future;
       } else {
-        var pendingTransition = _transition?.future;
+        Future pendingTransition;
+        if (_transition != null && !_transition.isCompleted) {
+          pendingTransition = _transition?.future;
+        }
         _previousState = _state;
         _state = LifecycleState.unloading;
         unloadingTransitionFuture = _unload(pendingTransition);

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -348,9 +348,13 @@ void main() {
         });
 
         test('can still be disposed', () {
-          module.didLoad.listen((_) {}, onError: expectAsync1((error) {
-            module.dispose().then(expectAsync1((_) {}));
-          }));
+          final completer = new Completer();
+          completer.future.then(expectAsync1((_) {}));
+
+          module.didLoad.listen((_) {}, onError: (_) async {
+            await module.dispose().then(completer.complete);
+          });
+
           expect(module.load(), throwsA(same(module.onLoadError)));
         });
       });
@@ -502,9 +506,13 @@ void main() {
         });
 
         test('can still be disposed', () {
-          module.didUnload.listen((_) {}, onError: expectAsync1((error) {
-            module.dispose().then(expectAsync1((_) {}));
-          }));
+          final completer = new Completer();
+          completer.future.then(expectAsync1((_) {}));
+
+          module.didUnload.listen((_) {}, onError: (_) async {
+            await module.dispose().then(completer.complete);
+          });
+
           expect(module.unload(), throwsA(same(module.onUnloadError)));
         });
       });
@@ -705,9 +713,13 @@ void main() {
         });
 
         test('can still be disposed', () {
-          module.didSuspend.listen((_) {}, onError: expectAsync1((error) {
-            module.dispose().then(expectAsync1((_) {}));
-          }));
+          final completer = new Completer();
+          completer.future.then(expectAsync1((_) {}));
+
+          module.didSuspend.listen((_) {}, onError: (_) async {
+            await module.dispose().then(completer.complete);
+          });
+
           expect(module.suspend(), throwsA(same(module.onSuspendError)));
         });
       });
@@ -844,9 +856,12 @@ void main() {
         });
 
         test('can still be disposed', () {
-          module.didResume.listen((_) {}, onError: expectAsync1((error) {
-            module.dispose().then(expectAsync1((_) {}));
-          }));
+          final completer = new Completer();
+          completer.future.then(expectAsync1((_) {}));
+
+          module.didResume.listen((_) {}, onError: (_) async {
+            await module.dispose().then(completer.complete);
+          });
 
           expect(module.resume(), throwsA(same(module.onResumeError)));
         });

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -347,9 +347,9 @@ void main() {
           expect(module.load(), throwsA(same(module.onLoadError)));
         });
 
-        test('should enter the loaded state regardless', () {
+        test('can still be disposed', () {
           module.didLoad.listen((_) {}, onError: expectAsync1((error) {
-            expect(module.isLoaded, isTrue);
+            module.dispose().then(expectAsync1((_) {}));
           }));
           expect(module.load(), throwsA(same(module.onLoadError)));
         });
@@ -501,9 +501,9 @@ void main() {
           expect(module.unload(), throwsA(same(module.onUnloadError)));
         });
 
-        test('should enter unloaded state regardless', () {
+        test('can still be disposed', () {
           module.didUnload.listen((_) {}, onError: expectAsync1((error) {
-            expect(module.isUnloaded, isTrue);
+            module.dispose().then(expectAsync1((_) {}));
           }));
           expect(module.unload(), throwsA(same(module.onUnloadError)));
         });
@@ -704,9 +704,9 @@ void main() {
           expect(module.suspend(), throwsA(same(module.onSuspendError)));
         });
 
-        test('should end up in loaded state.', () {
+        test('can still be disposed', () {
           module.didSuspend.listen((_) {}, onError: expectAsync1((error) {
-            expect(module.isLoaded, isTrue);
+            module.dispose().then(expectAsync1((_) {}));
           }));
           expect(module.suspend(), throwsA(same(module.onSuspendError)));
         });
@@ -843,9 +843,9 @@ void main() {
           expect(module.resume(), throwsA(same(module.onResumeError)));
         });
 
-        test('should end up in suspended state', () {
+        test('can still be disposed', () {
           module.didResume.listen((_) {}, onError: expectAsync1((error) {
-            expect(module.isSuspended, isTrue);
+            module.dispose().then(expectAsync1((_) {}));
           }));
 
           expect(module.resume(), throwsA(same(module.onResumeError)));

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -347,14 +347,14 @@ void main() {
           expect(module.load(), throwsA(same(module.onLoadError)));
         });
 
-        test('should not repeatedly emit that error for subsequent transitions', () async {
+        test('should not repeatedly emit that error for subsequent transitions',
+            () async {
           Completer done = new Completer();
           // ignore: unawaited_futures
-          done.future.then(expectAsync1((_){}));
+          done.future.then(expectAsync1((_) {}));
 
           module.didLoad.listen((_) {},
               onError: expectAsync2((Error error, StackTrace stackTrace) async {
-
             try {
               await module.unload().then(done.complete);
             } catch (e) {
@@ -729,14 +729,14 @@ void main() {
           expect(module.suspend(), throwsA(same(module.onSuspendError)));
         });
 
-        test('should not repeatedly emit that error for subsequent transitions', () async {
+        test('should not repeatedly emit that error for subsequent transitions',
+            () async {
           Completer done = new Completer();
           // ignore: unawaited_futures
-          done.future.then(expectAsync1((_){}));
+          done.future.then(expectAsync1((_) {}));
 
           module.didSuspend.listen((_) {},
               onError: expectAsync2((Error error, StackTrace stackTrace) async {
-
             try {
               await module.unload().then(done.complete);
             } catch (e) {
@@ -889,14 +889,14 @@ void main() {
           expect(module.resume(), throwsA(same(module.onResumeError)));
         });
 
-        test('should not repeatedly emit that error for subsequent transitions', () async {
+        test('should not repeatedly emit that error for subsequent transitions',
+            () async {
           Completer done = new Completer();
           // ignore: unawaited_futures
-          done.future.then(expectAsync1((_){}));
+          done.future.then(expectAsync1((_) {}));
 
           module.didResume.listen((_) {},
               onError: expectAsync2((Error error, StackTrace stackTrace) async {
-
             try {
               await module.unload().then(done.complete);
             } catch (e) {

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -346,6 +346,13 @@ void main() {
           }));
           expect(module.load(), throwsA(same(module.onLoadError)));
         });
+
+        test('should enter the loaded state regardless', () {
+          module.didLoad.listen((_) {}, onError: expectAsync1((error) {
+            expect(module.isLoaded, isTrue);
+          }));
+          expect(module.load(), throwsA(same(module.onLoadError)));
+        });
       });
 
       test('should set isLoaded', () async {
@@ -490,6 +497,13 @@ void main() {
               onError: expectAsync2((Error error, StackTrace stackTrace) {
             expect(error, same(module.onUnloadError));
             expect(stackTrace, isNotNull);
+          }));
+          expect(module.unload(), throwsA(same(module.onUnloadError)));
+        });
+
+        test('should enter unloaded state regardless', () {
+          module.didUnload.listen((_) {}, onError: expectAsync1((error) {
+            expect(module.isUnloaded, isTrue);
           }));
           expect(module.unload(), throwsA(same(module.onUnloadError)));
         });
@@ -689,6 +703,13 @@ void main() {
           }));
           expect(module.suspend(), throwsA(same(module.onSuspendError)));
         });
+
+        test('should end up in loaded state.', () {
+          module.didSuspend.listen((_) {}, onError: expectAsync1((error) {
+            expect(module.isLoaded, isTrue);
+          }));
+          expect(module.suspend(), throwsA(same(module.onSuspendError)));
+        });
       });
 
       test('should set isSuspending', () async {
@@ -819,6 +840,14 @@ void main() {
             expect(error, same(module.onResumeError));
             expect(stackTrace, isNotNull);
           }));
+          expect(module.resume(), throwsA(same(module.onResumeError)));
+        });
+
+        test('should end up in suspended state', () {
+          module.didResume.listen((_) {}, onError: expectAsync1((error) {
+            expect(module.isSuspended, isTrue);
+          }));
+
           expect(module.resume(), throwsA(same(module.onResumeError)));
         });
       });

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -347,6 +347,23 @@ void main() {
           expect(module.load(), throwsA(same(module.onLoadError)));
         });
 
+        test('should not repeatedly emit that error for subsequent transitions', () async {
+          Completer done = new Completer();
+          // ignore: unawaited_futures
+          done.future.then(expectAsync1((_){}));
+
+          module.didLoad.listen((_) {},
+              onError: expectAsync2((Error error, StackTrace stackTrace) async {
+
+            try {
+              await module.unload().then(done.complete);
+            } catch (e) {
+              fail('Expected unload to succeed, got $e');
+            }
+          }));
+          expect(module.load(), throwsA(same(module.onLoadError)));
+        });
+
         test('can still be disposed', () {
           final completer = new Completer();
           completer.future.then(expectAsync1((_) {}));
@@ -712,6 +729,23 @@ void main() {
           expect(module.suspend(), throwsA(same(module.onSuspendError)));
         });
 
+        test('should not repeatedly emit that error for subsequent transitions', () async {
+          Completer done = new Completer();
+          // ignore: unawaited_futures
+          done.future.then(expectAsync1((_){}));
+
+          module.didSuspend.listen((_) {},
+              onError: expectAsync2((Error error, StackTrace stackTrace) async {
+
+            try {
+              await module.unload().then(done.complete);
+            } catch (e) {
+              fail('Expected unload to succeed, got $e');
+            }
+          }));
+          expect(module.suspend(), throwsA(same(module.onSuspendError)));
+        });
+
         test('can still be disposed', () {
           final completer = new Completer();
           completer.future.then(expectAsync1((_) {}));
@@ -851,6 +885,23 @@ void main() {
               onError: expectAsync2((Error error, StackTrace stackTrace) {
             expect(error, same(module.onResumeError));
             expect(stackTrace, isNotNull);
+          }));
+          expect(module.resume(), throwsA(same(module.onResumeError)));
+        });
+
+        test('should not repeatedly emit that error for subsequent transitions', () async {
+          Completer done = new Completer();
+          // ignore: unawaited_futures
+          done.future.then(expectAsync1((_){}));
+
+          module.didResume.listen((_) {},
+              onError: expectAsync2((Error error, StackTrace stackTrace) async {
+
+            try {
+              await module.unload().then(done.complete);
+            } catch (e) {
+              fail('Expected unload to succeed, got $e');
+            }
           }));
           expect(module.resume(), throwsA(same(module.onResumeError)));
         });


### PR DESCRIPTION
# Problem

If a module has an uncaught exception during an error, it is impossible to unload because it is in the middle of a transition.

# Solution

Specifically revert state back if a transition fails and clear the `_transition` completer so that the error that caused the transition to fail is not repeatedly consumed on subsequent `unload()` calls.

# Testing Suggestion

- [ ] CI passes