### PR TITLE
WP-5419 Release w_module 1.5.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_module
-version: 1.5.0
+version: 1.5.1
 description: Base module classes with a well defined lifecycle for modular Dart applications.
 authors:
   - Workiva Client Platform Team <team-clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4919 Unblock mid-transition states](https://github.com/Workiva/w_module/pull/103)
* [WP-5633 Add CODEOWNERS file](https://github.com/Workiva/w_module/pull/105)
* [WP-5746 w_module should follow new logger name standard](https://github.com/Workiva/w_module/pull/106)


Requested by: @maxpeterson-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_module/compare/1.5.0...Workiva:release_w_module_1_5_1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_module/compare/1.5.0...1.5.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5416683323785216/logs/)