### PR TITLE
Replace dart:mirrors with package:reflectable

### DIFF
--- a/lib/src/serializable.dart
+++ b/lib/src/serializable.dart
@@ -26,10 +26,11 @@ import 'package:w_module/src/module.dart';
 
 // Any classes / methods that are going to be reflected must annotate with this
 class Reflectable extends reflect.Reflectable {
-  const Reflectable() :super(
-    reflect.invokingCapability, 
-    reflect.typingCapability,
-    );
+  const Reflectable()
+      : super(
+          reflect.invokingCapability,
+          reflect.typingCapability,
+        );
 }
 
 const _reflector = const Reflectable();
@@ -138,7 +139,6 @@ class SerializableBus {
 
   void _deserializeAndCall(
       SerializableModule module, String method, List data) {
-        
     reflect.InstanceMirror apiMirror = _reflector.reflect(module.api);
 
     if (apiMirror == null) {
@@ -167,12 +167,12 @@ class SerializableBus {
     for (var i = 0; i < apiMethodMirror.parameters.length; i++) {
       reflect.ParameterMirror param = apiMethodMirror.parameters[i];
       if (data[i] is Map && param.type.reflectedType != Map) {
-        reflect.ClassMirror paramClassMirror = _reflector.reflectType(param.type.reflectedType);
+        reflect.ClassMirror paramClassMirror =
+            _reflector.reflectType(param.type.reflectedType);
 
         // Paramter type must implement fromJson name constructor that takes a Map
         try {
-          var instance = paramClassMirror
-              .newInstance('fromJson', [data[i]]);
+          var instance = paramClassMirror.newInstance('fromJson', [data[i]]);
           reflectedData[i] = instance;
         } on NoSuchMethodError {
           _logger.warning(

--- a/lib/src/serializable.dart
+++ b/lib/src/serializable.dart
@@ -15,9 +15,8 @@
 library serializable_module.src.serializable;
 
 import 'dart:async';
-@MirrorsUsed(metaTargets: 'serializable_module.src.serializable.Reflectable')
-import 'dart:mirrors';
 
+import 'package:reflectable/reflectable.dart' as reflect;
 import 'package:logging/logging.dart';
 import 'package:w_common/disposable.dart' show Disposable;
 import 'package:w_common/json_serializable.dart' show JsonSerializable;
@@ -26,9 +25,14 @@ import 'package:w_module/src/event.dart';
 import 'package:w_module/src/module.dart';
 
 // Any classes / methods that are going to be reflected must annotate with this
-class Reflectable {
-  const Reflectable();
+class Reflectable extends reflect.Reflectable {
+  const Reflectable() :super(
+    reflect.invokingCapability, 
+    reflect.typingCapability,
+    );
 }
+
+const _reflector = const Reflectable();
 
 abstract class Bridge<T> extends Object with Disposable {
   final Stream<Map> apiCallReceived;
@@ -134,8 +138,8 @@ class SerializableBus {
 
   void _deserializeAndCall(
       SerializableModule module, String method, List data) {
-    InstanceMirror apiMirror = reflect(module.api);
-    List reflectedData = new List(data.length);
+        
+    reflect.InstanceMirror apiMirror = _reflector.reflect(module.api);
 
     if (apiMirror == null) {
       _logger.warning(
@@ -143,8 +147,8 @@ class SerializableBus {
       return;
     }
 
-    ClassMirror classMirror = apiMirror.type;
-    MethodMirror apiMethodMirror = classMirror.declarations[new Symbol(method)];
+    reflect.ClassMirror classMirror = apiMirror.type;
+    reflect.MethodMirror apiMethodMirror = classMirror.declarations[method];
 
     if (apiMethodMirror == null) {
       _logger.warning(
@@ -159,16 +163,16 @@ class SerializableBus {
       return;
     }
 
+    List reflectedData = new List(data.length);
     for (var i = 0; i < apiMethodMirror.parameters.length; i++) {
-      var param = apiMethodMirror.parameters[i];
-
+      reflect.ParameterMirror param = apiMethodMirror.parameters[i];
       if (data[i] is Map && param.type.reflectedType != Map) {
-        ClassMirror paramClassMirror = reflectClass(param.type.reflectedType);
+        reflect.ClassMirror paramClassMirror = _reflector.reflectType(param.type.reflectedType);
 
         // Paramter type must implement fromJson name constructor that takes a Map
         try {
           var instance = paramClassMirror
-              .newInstance(new Symbol('fromJson'), [data[i]]).reflectee;
+              .newInstance('fromJson', [data[i]]);
           reflectedData[i] = instance;
         } on NoSuchMethodError {
           _logger.warning(
@@ -179,7 +183,7 @@ class SerializableBus {
     }
 
     try {
-      apiMirror.invoke(new Symbol(method), reflectedData);
+      apiMirror.invoke(method, reflectedData);
     } catch (e) {
       _logger.severe(
           'Unable to call $method on ${module.serializableKey} w_module, ${e.toString()}');

--- a/lib/src/serializable.dart
+++ b/lib/src/serializable.dart
@@ -139,7 +139,7 @@ class SerializableBus {
 
   void _deserializeAndCall(
       SerializableModule module, String method, List data) {
-    reflect.InstanceMirror apiMirror = _reflector.reflect(module.api);
+    var apiMirror = _reflector.reflect(module.api);
 
     if (apiMirror == null) {
       _logger.warning(
@@ -147,8 +147,9 @@ class SerializableBus {
       return;
     }
 
-    reflect.ClassMirror classMirror = apiMirror.type;
-    reflect.MethodMirror apiMethodMirror = classMirror.declarations[method];
+    var classMirror = apiMirror.type;
+    var apiMethodMirror = classMirror.declarations[method] // ignore: avoid_as
+        as reflect.MethodMirror;
 
     if (apiMethodMirror == null) {
       _logger.warning(
@@ -165,10 +166,12 @@ class SerializableBus {
 
     List reflectedData = new List(data.length);
     for (var i = 0; i < apiMethodMirror.parameters.length; i++) {
-      reflect.ParameterMirror param = apiMethodMirror.parameters[i];
+      var param = apiMethodMirror.parameters[i];
       if (data[i] is Map && param.type.reflectedType != Map) {
-        reflect.ClassMirror paramClassMirror =
-            _reflector.reflectType(param.type.reflectedType);
+        var paramClassMirror =
+            // ignore: avoid_as
+            _reflector.reflectType(param.type.reflectedType)
+                as reflect.ClassMirror;
 
         // Paramter type must implement fromJson name constructor that takes a Map
         try {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,3 +34,6 @@ environment:
 transformers:
   - test/pub_serve:
       $include: test/**_test{.*,}dart
+  - reflectable:
+      entry_points:
+        - test/serializable_test.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   meta: ^1.0.0
   platform_detect: ^1.1.0
   w_common: ^1.9.0
+  reflectable: ^1.0.3
 
 dev_dependencies:
   browser: ^0.10.0+2

--- a/test/serializable_test.dart
+++ b/test/serializable_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn('vm || browser')
+@TestOn('browser')
 import 'dart:async';
 
 import 'package:mockito/mockito.dart';


### PR DESCRIPTION
# Problem
dart:mirrors is going away in Dart 2. It also results in large JS output, even with the @MirrorsUsed annotations.

# Solution
Replace it with the reflectable package

# Testing
 - [ ] Test with w_viewer_mobile and the mobile wdesk app ( cc @brianblanchard-wf )
 - [ ] Ensure no regressions in consumers (wdesk_sdk, product lines)