### PR TITLE
Hide lifecycle logs by default 🤫

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   - [**Disposal**](#disposal)
 - [**Examples**](#examples)
 - [**Development**](#development)
+- [**URL Parameters**](#url-parameters)
 
 
 ---
@@ -426,3 +427,7 @@ This project leverages [the dart_dev package](https://pub.dartlang.org/packages/
 for most of its tooling needs, including static analysis, code formatting,
 running tests, collecting coverage, and serving examples. Check out
 [the dart_dev readme](https://github.com/Workiva/dart_dev) for more information.
+
+### URL Parameters
+
+`?w_module.verbose=true` turns on verbose debug logging, particularly module lifecycle logging.

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -18,7 +18,7 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart'
-    show mustCallSuper, protected, required, visibleForTesting;
+    show mustCallSuper, protected, required;
 import 'package:w_common/disposable.dart';
 
 import 'package:w_module/src/simple_module.dart';
@@ -53,7 +53,9 @@ enum LifecycleState {
 /// Intended to be extended by most base module classes in order to provide a
 /// unified lifecycle API.
 abstract class LifecycleModule extends SimpleModule with Disposable {
-  @visibleForTesting
+  /// Enables verbose logging for this module.
+  /// 
+  /// Globally overridden by the 'w_module.verbose' url parameter.
   bool verboseLogging = false;
   List<LifecycleModule> _childModules = [];
   Logger _logger;

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -17,7 +17,7 @@ library w_module.src.lifecycle_module;
 import 'dart:async';
 
 import 'package:logging/logging.dart';
-import 'package:meta/meta.dart' show mustCallSuper, protected, required;
+import 'package:meta/meta.dart' show mustCallSuper, protected, required, visibleForTesting;
 import 'package:w_common/disposable.dart';
 
 import 'package:w_module/src/simple_module.dart';
@@ -52,6 +52,8 @@ enum LifecycleState {
 /// Intended to be extended by most base module classes in order to provide a
 /// unified lifecycle API.
 abstract class LifecycleModule extends SimpleModule with Disposable {
+  @visibleForTesting
+  bool verboseLogging = false;
   List<LifecycleModule> _childModules = [];
   Logger _logger;
   String _name;
@@ -792,7 +794,9 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   void _logLifecycleEvents(
       String logLabel, Stream<dynamic> lifecycleEventStream) {
 
-    listenToStream(lifecycleEventStream, (_) { if (Uri.base.queryParameters['w_module.verbose'] == 'true') {_logger.fine(logLabel);}},
+    listenToStream(lifecycleEventStream, (_) {
+      if (Uri.base.queryParameters['w_module.verbose'] == 'true' || verboseLogging) {
+        _logger.fine(logLabel);}},
         onError: (error) => _logger.warning('$logLabel error: $error'));
   }
 

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -17,8 +17,7 @@ library w_module.src.lifecycle_module;
 import 'dart:async';
 
 import 'package:logging/logging.dart';
-import 'package:meta/meta.dart'
-    show mustCallSuper, protected, required;
+import 'package:meta/meta.dart' show mustCallSuper, protected, required;
 import 'package:w_common/disposable.dart';
 
 import 'package:w_module/src/simple_module.dart';
@@ -54,7 +53,7 @@ enum LifecycleState {
 /// unified lifecycle API.
 abstract class LifecycleModule extends SimpleModule with Disposable {
   /// Enables verbose logging for this module.
-  /// 
+  ///
   /// Globally overridden by the 'w_module.verbose' url parameter.
   bool verboseLogging = false;
   List<LifecycleModule> _childModules = [];

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -791,7 +791,8 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   /// A utility to logging LifecycleModule lifecycle events
   void _logLifecycleEvents(
       String logLabel, Stream<dynamic> lifecycleEventStream) {
-    listenToStream(lifecycleEventStream, (_) => _logger.fine(logLabel),
+
+    listenToStream(lifecycleEventStream, (_) { if (Uri.base.queryParameters['w_module.verbose'] == 'true') {_logger.fine(logLabel);}},
         onError: (error) => _logger.warning('$logLabel error: $error'));
   }
 

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -17,7 +17,8 @@ library w_module.src.lifecycle_module;
 import 'dart:async';
 
 import 'package:logging/logging.dart';
-import 'package:meta/meta.dart' show mustCallSuper, protected, required, visibleForTesting;
+import 'package:meta/meta.dart'
+    show mustCallSuper, protected, required, visibleForTesting;
 import 'package:w_common/disposable.dart';
 
 import 'package:w_module/src/simple_module.dart';
@@ -793,11 +794,12 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   /// A utility to logging LifecycleModule lifecycle events
   void _logLifecycleEvents(
       String logLabel, Stream<dynamic> lifecycleEventStream) {
-
     listenToStream(lifecycleEventStream, (_) {
-      if (Uri.base.queryParameters['w_module.verbose'] == 'true' || verboseLogging) {
-        _logger.fine(logLabel);}},
-        onError: (error) => _logger.warning('$logLabel error: $error'));
+      if (Uri.base.queryParameters['w_module.verbose'] == 'true' ||
+          verboseLogging) {
+        _logger.fine(logLabel);
+      }
+    }, onError: (error) => _logger.warning('$logLabel error: $error'));
   }
 
   /// Handles a child [LifecycleModule]'s [didUnload] event.

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -51,6 +51,7 @@ class TestLifecycleModule extends LifecycleModule {
   bool mockShouldUnload;
 
   TestLifecycleModule({String name}) : name = name ?? 'TestLifecycleModule' {
+    verboseLogging = true;
     // init test validation data
     eventList = [];
     mockShouldUnload = true;


### PR DESCRIPTION
# Problem 
Module lifecycle logs are pretty noisy.  They are hard to filter, also.  If you filter out console logs that have either w_module or LifecycleModule in them, you wipe out many exceptions, because most of our ecosystem extends from LifeCycleModules.

# Solution
Keep error logging on, but hide normal lifecycle logs behind a url parameter, `w_module.verbose=true`

# Example
The amount of lifecycle logging before:
![screen shot 2018-05-02 at 8 54 34 am](https://user-images.githubusercontent.com/8027264/39530956-5421be7a-4de7-11e8-82f2-79e2a2c78e17.png)

After (notice the length of the scrollbar pill):
![image](https://user-images.githubusercontent.com/8027264/39531088-a5eefca4-4de7-11e8-81fd-54b908987890.png)

