### PR TITLE
af-266 : log at finest

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -791,7 +791,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   /// A utility to logging LifecycleModule lifecycle events
   void _logLifecycleEvents(
       String logLabel, Stream<dynamic> lifecycleEventStream) {
-    listenToStream(lifecycleEventStream, (_) => _logger.fine(logLabel),
+    listenToStream(lifecycleEventStream, (_) => _logger.finest(logLabel),
         onError: (error) => _logger.warning('$logLabel error: $error'));
   }
 

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -323,8 +323,8 @@ void main() {
         expect(
             Logger.root.onRecord,
             emitsInOrder([
-              logRecord(level: Level.FINE, message: equals('willLoad')),
-              logRecord(level: Level.FINE, message: equals('didLoad')),
+              logRecord(level: Level.FINEST, message: equals('willLoad')),
+              logRecord(level: Level.FINEST, message: equals('didLoad')),
             ]));
 
         await module.load();
@@ -495,8 +495,8 @@ void main() {
         expect(
             Logger.root.onRecord,
             emitsInOrder([
-              logRecord(level: Level.FINE, message: equals('willUnload')),
-              logRecord(level: Level.FINE, message: equals('didUnload')),
+              logRecord(level: Level.FINEST, message: equals('willUnload')),
+              logRecord(level: Level.FINEST, message: equals('didUnload')),
             ]));
 
         await module.unload();
@@ -704,8 +704,8 @@ void main() {
         expect(
             Logger.root.onRecord,
             emitsInOrder([
-              logRecord(level: Level.FINE, message: equals('willSuspend')),
-              logRecord(level: Level.FINE, message: equals('didSuspend')),
+              logRecord(level: Level.FINEST, message: equals('willSuspend')),
+              logRecord(level: Level.FINEST, message: equals('didSuspend')),
             ]));
 
         await module.suspend();
@@ -864,8 +864,8 @@ void main() {
         expect(
             Logger.root.onRecord,
             emitsInOrder([
-              logRecord(level: Level.FINE, message: equals('willResume')),
-              logRecord(level: Level.FINE, message: equals('didResume')),
+              logRecord(level: Level.FINEST, message: equals('willResume')),
+              logRecord(level: Level.FINEST, message: equals('didResume')),
             ]));
 
         await module.resume();
@@ -1300,25 +1300,25 @@ void main() {
             Logger.root.onRecord,
             emitsInOrder([
               logRecord(
-                level: Level.FINE,
+                level: Level.FINEST,
                 message: equals('willLoadChildModule'),
                 loggerName:
                     equals('w_module.LifecycleModule:${parentModule.name}'),
               ),
               logRecord(
-                level: Level.FINE,
+                level: Level.FINEST,
                 message: equals('willLoad'),
                 loggerName:
                     equals('w_module.LifecycleModule:${childModule.name}'),
               ),
               logRecord(
-                level: Level.FINE,
+                level: Level.FINEST,
                 message: equals('didLoad'),
                 loggerName:
                     equals('w_module.LifecycleModule:${childModule.name}'),
               ),
               logRecord(
-                level: Level.FINE,
+                level: Level.FINEST,
                 message: equals('didLoadChildModule'),
                 loggerName:
                     equals('w_module.LifecycleModule:${parentModule.name}'),
@@ -1539,31 +1539,31 @@ void main() {
             Logger.root.onRecord,
             emitsInOrder([
               logRecord(
-                level: Level.FINE,
+                level: Level.FINEST,
                 message: equals('willUnload'),
                 loggerName:
                     equals('w_module.LifecycleModule:${parentModule.name}'),
               ),
               logRecord(
-                level: Level.FINE,
+                level: Level.FINEST,
                 message: equals('willUnload'),
                 loggerName:
                     equals('w_module.LifecycleModule:${childModule.name}'),
               ),
               logRecord(
-                level: Level.FINE,
+                level: Level.FINEST,
                 message: equals('willUnloadChildModule'),
                 loggerName:
                     equals('w_module.LifecycleModule:${parentModule.name}'),
               ),
               logRecord(
-                level: Level.FINE,
+                level: Level.FINEST,
                 message: equals('didUnload'),
                 loggerName:
                     equals('w_module.LifecycleModule:${childModule.name}'),
               ),
               logRecord(
-                level: Level.FINE,
+                level: Level.FINEST,
                 message: equals('didUnloadChildModule'),
                 loggerName:
                     equals('w_module.LifecycleModule:${parentModule.name}'),


### PR DESCRIPTION
## Problem
We're jamming up our browser console with info-logs.  From the discussion on https://docs.google.com/document/d/1Qsn333r3i92qTLVW7Lp2IHU7m5YAUh7kOWNOYLliul4/edit?ts=5af3033e#

It seemed like a good idea to move these logs down one level of logging severity.

## Solution

Logs emitted by this library are at 'finest' level.  Exceptions continue to be logged as warnings.
