### PR TITLE
AF-1656 - Tracing for lifecycle transitions

### DIFF
--- a/example/panel/modules/sample_tracer.dart
+++ b/example/panel/modules/sample_tracer.dart
@@ -1,0 +1,162 @@
+import 'dart:async';
+import 'package:opentracing/opentracing.dart';
+
+class SampleSpan implements Span {
+  static int _nextId = 0;
+  final int _id = _nextId++;
+
+  @override
+  final List<Reference> references;
+
+  @override
+  final Map<String, dynamic> tags;
+
+  @override
+  final List<LogData> logData = [];
+
+  @override
+  final String operationName;
+
+  @override
+  SpanContext context;
+
+  @override
+  final DateTime startTime;
+  DateTime _endTime;
+
+  Completer<Span> _whenFinished = new Completer<Span>();
+
+  SampleSpan(
+    this.operationName, {
+    SpanContext childOf,
+    this.references,
+    DateTime startTime,
+    Map<String, dynamic> tags,
+  })
+      : this.startTime = startTime ?? new DateTime.now(),
+        this.tags = tags ?? {} {
+    if (childOf != null) {
+      references.add(new Reference.childOf(childOf));
+    }
+    setTag('span.kind', 'client');
+
+    final parent = parentContext;
+    if (parent != null) {
+      this.context = new SpanContext(spanId: _id, traceId: parent.traceId);
+      this.context.baggage.addAll(parent.baggage);
+    } else {
+      this.context = new SpanContext(spanId: _id, traceId: _id);
+    }
+  }
+
+  @override
+  void addTags(Map<String, dynamic> newTags) => tags.addAll(newTags);
+
+  @override
+  Duration get duration => _endTime?.difference(startTime);
+
+  @override
+  DateTime get endTime => _endTime;
+
+  @override
+  void finish({DateTime finishTime}) {
+    if (_whenFinished == null) {
+      return;
+    }
+
+    _endTime = finishTime ?? new DateTime.now();
+    _whenFinished.complete(this);
+    _whenFinished = null;
+  }
+
+  @override
+  void log(String event, {dynamic payload, DateTime timestamp}) =>
+      logData.add(new LogData(timestamp ?? new DateTime.now(), event, payload));
+
+  @override
+  SpanContext get parentContext =>
+      references.isEmpty ? null : references.first.referencedContext;
+
+  @override
+  void setTag(String tagName, dynamic value) => tags[tagName] = value;
+
+  @override
+  Future<Span> get whenFinished => _whenFinished.future;
+
+  @override
+  String toString() {
+    final sb = new StringBuffer('SampleSpan(');
+    sb
+      ..writeln('traceId: ${context.traceId}')
+      ..writeln('spanId: ${context.spanId}')
+      ..writeln('operationName: $operationName')
+      ..writeln('tags: ${tags.toString()}')
+      ..writeln('startTime: ${startTime.toString()}');
+
+    if (_endTime != null) {
+      sb
+        ..writeln('endTime: ${endTime.toString()}')
+        ..writeln('duration: ${duration.toString()}');
+    }
+
+    if (logData.isNotEmpty) {
+      sb.writeln('logData: ${logData.toString()}');
+    }
+
+    if (references.isNotEmpty) {
+      final reference = references.first;
+      sb.writeln(
+          'reference: ${reference.referenceType} ${reference.referencedContext.spanId}');
+    }
+
+    sb.writeln(')');
+
+    return sb.toString();
+  }
+}
+
+class SampleTracer implements AbstractTracer {
+  @override
+  SampleSpan startSpan(
+    String operationName, {
+    SpanContext childOf,
+    List<Reference> references,
+    DateTime startTime,
+    Map<String, dynamic> tags,
+  }) {
+    return new SampleSpan(
+      operationName,
+      childOf: childOf,
+      references: references,
+      startTime: startTime,
+      tags: tags,
+    )
+      ..whenFinished.then((span) {
+        print(span.toString());
+      });
+  }
+
+  @override
+  Reference childOf(SpanContext context) => new Reference.childOf(context);
+
+  @override
+  Reference followsFrom(SpanContext context) =>
+      new Reference.followsFrom(context);
+
+  @override
+  SpanContext extract(String format, dynamic carrier) {
+    throw new UnimplementedError(
+        'Sample tracer for example purposes does not support advanced tracing behavior.');
+  }
+
+  @override
+  void inject(SpanContext spanContext, String format, dynamic carrier) {
+    throw new UnimplementedError(
+        'Sample tracer for example purposes does not support advanced tracing behavior.');
+  }
+
+  @override
+  Future<dynamic> flush() {
+    return null;
+  }
+}

--- a/example/panel/panel_app.dart
+++ b/example/panel/panel_app.dart
@@ -22,12 +22,18 @@ import 'package:platform_detect/platform_detect.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart' as react_client;
 import 'package:w_module/w_module.dart' hide Event;
+import 'package:opentracing/opentracing.dart';
 
 import 'modules/panel_module.dart';
+import 'modules/sample_tracer.dart';
 
 Future<Null> main() async {
   Element container = querySelector('#panel-container');
   react_client.setClientConfiguration();
+
+  final tracer = new SampleTracer();
+  initGlobalTracer(tracer);
+  assert(globalTracer() == tracer);
 
   // instantiate the core app module and wait for it to complete loading
   PanelModule panelModule = new PanelModule();

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -456,7 +456,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
 
       try {
         _childModules.add(childModule);
-        childModule._parentContext = _activeSpan?.context;
+        childModule._parentContext = _loadSpanContext;
 
         await childModule.load();
         await onDidLoadChildModule(childModule);

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -158,8 +158,9 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   /// Builds a span that conditionally applies a followsFrom reference if this module
   /// was loaded by a parent module.
   ///
-  /// Returns `null` if this module does not override the [name] getter or if
-  /// if no globalTracer is configured.
+  /// Returns `null` if no globalTracer is configured, or if this module does
+  /// not override the [name] getter (as the default name becomes nonsensical
+  /// when compiled to js).
   Span _startTransitionSpan(String operationName) {
     if (name == _name) {
       return null;

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -59,7 +59,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
 
   List<LifecycleModule> _childModules = [];
   Logger _logger;
-  String _name;
+  String _defaultName;
   LifecycleState _previousState;
   LifecycleState _state = LifecycleState.instantiated;
   Completer<Null> _transition;
@@ -133,7 +133,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       'didUnload': didUnload,
     }.forEach(_logLifecycleEvents);
 
-    _name = 'LifecycleModule($runtimeType)';
+    _defaultName = 'LifecycleModule($runtimeType)';
   }
 
   /// If this module is in a transition state, this is the Span capturing the
@@ -162,7 +162,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   /// not override the [name] getter (as the default name becomes nonsensical
   /// when compiled to js).
   Span _startTransitionSpan(String operationName) {
-    if (name == _name) {
+    if (name == _defaultName) {
       return null;
     }
 
@@ -186,14 +186,14 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
 
   /// Name of the module for identification in exceptions and debug messages.
   // ignore: unnecessary_getters_setters
-  String get name => _name;
+  String get name => _defaultName;
 
   /// Deprecated: the module name should be defined by overriding the getter in
   /// a subclass and it should not be mutable.
   @deprecated
   // ignore: unnecessary_getters_setters
   set name(String newName) {
-    _name = newName;
+    _defaultName = newName;
   }
 
   /// List of child components so that lifecycle can iterate over them as needed

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -456,7 +456,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
 
       try {
         _childModules.add(childModule);
-        childModule._parentContext = _loadSpanContext;
+        childModule._parentContext = _activeSpan?.context;
 
         await childModule.load();
         await onDidLoadChildModule(childModule);

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -524,13 +524,9 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
 
     Future pendingTransition;
     if (_transition != null && !_transition.isCompleted) {
-      pendingTransition = _transition.future
-          // Need to `catchError` before `whenComplete` to prevent errors from
-          // getting thrown here when they should be handled elsewhere
-          .catchError((_) {})
-            ..whenComplete(() {
-              _activeSpan = _startTransitionSpan('suspend');
-            });
+      pendingTransition = _transition.future.then((_) {
+        _activeSpan = _startTransitionSpan('suspend');
+      });
     } else {
       _activeSpan = _startTransitionSpan('suspend');
     }
@@ -595,13 +591,9 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
 
     Future pendingTransition;
     if (_transition != null && !_transition.isCompleted) {
-      pendingTransition = _transition.future
-          // Need to `catchError` before `whenComplete` to prevent errors from
-          // getting thrown here when they should be handled elsewhere
-          .catchError((_) {})
-            ..whenComplete(() {
-              _activeSpan = _startTransitionSpan('resume');
-            });
+      pendingTransition = _transition.future.then((_) {
+        _activeSpan = _startTransitionSpan('resume');
+      });
     } else {
       _activeSpan = _startTransitionSpan('resume');
     }

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -347,7 +347,6 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
           reason: 'A module can only be loaded once.');
     }
 
-    // TODO childOf or followsFrom
     _span = _startTransitionSpan('load($name)');
 
     _state = LifecycleState.loading;

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -530,11 +530,9 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
         .then(transition.complete)
         .catchError((error, trace) {
       transition.completeError(error, trace);
-      assert(activeSpan != null);
-      _activeSpan.setTag('error', true);
+      _activeSpan?.setTag('error', true);
     }).whenComplete(() {
-      assert(activeSpan != null);
-      _activeSpan.finish();
+      _activeSpan?.finish();
       _activeSpan = null;
     });
 

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -132,6 +132,8 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       'willUnload': willUnload,
       'didUnload': didUnload,
     }.forEach(_logLifecycleEvents);
+
+    _name = 'LifecycleModule($runtimeType)';
   }
 
   /// If this module is in a transition state, this is the Span capturing the
@@ -183,7 +185,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
 
   /// Name of the module for identification in exceptions and debug messages.
   // ignore: unnecessary_getters_setters
-  String get name => _name ?? 'LifecycleModule($runtimeType)';
+  String get name => _name;
 
   /// Deprecated: the module name should be defined by overriding the getter in
   /// a subclass and it should not be mutable.

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -156,8 +156,13 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   /// Builds a span that conditionally applies a followsFrom reference if this module
   /// was loaded by a parent module.
   ///
-  /// Returns `null` if no globalTracer is configured.
+  /// Returns `null` if this module does not override the [name] getter or if
+  /// if no globalTracer is configured.
   Span _startTransitionSpan(String operationName) {
+    if (name == _name) {
+      return null;
+    }
+
     final tracer = globalTracer();
     if (tracer == null) {
       return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   logging: ^0.11.0
   meta: ^1.0.0
   platform_detect: ^1.1.0
+  opentracing: ^0.2.1
   w_common: ^1.9.0
 
 dev_dependencies:
@@ -23,7 +24,6 @@ dev_dependencies:
   dart_style: ^0.2.16
   dartdoc: ^0.9.0
   mockito: ^1.0.1
-  opentracing: ^0.2.1
   react: ^3.0.0
   test: ^0.12.0
   w_flux: '>=1.0.0 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dev_dependencies:
   dart_style: ^0.2.16
   dartdoc: ^0.9.0
   mockito: ^1.0.1
+  opentracing: ^0.2.1
   react: ^3.0.0
   test: ^0.12.0
   w_flux: '>=1.0.0 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,8 +13,8 @@ homepage: https://github.com/Workiva/w_module
 dependencies:
   logging: ^0.11.0
   meta: ^1.0.0
-  platform_detect: ^1.1.0
   opentracing: ^0.2.1
+  platform_detect: ^1.1.0
   w_common: ^1.9.0
 
 dev_dependencies:

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -137,7 +137,7 @@ class TestLifecycleModule extends LifecycleModule {
     if (onLoadError != null) {
       throw onLoadError;
     }
-    assert(activeSpan.operationName == 'load_module');
+    assert(activeSpan.operationName == 'LifecycleModule.load');
     activeSpan.setTag('custom.load.tag', 'somevalue');
     eventList.add('onLoad');
   }
@@ -170,7 +170,7 @@ class TestLifecycleModule extends LifecycleModule {
     if (onSuspendError != null) {
       throw onSuspendError;
     }
-    assert(activeSpan.operationName == 'suspend_module');
+    assert(activeSpan.operationName == 'LifecycleModule.suspend');
     activeSpan.setTag('custom.suspend.tag', 'somevalue');
     eventList.add('onSuspend');
   }
@@ -182,7 +182,7 @@ class TestLifecycleModule extends LifecycleModule {
     if (onResumeError != null) {
       throw onResumeError;
     }
-    assert(activeSpan.operationName == 'resume_module');
+    assert(activeSpan.operationName == 'LifecycleModule.resume');
     activeSpan.setTag('custom.resume.tag', 'somevalue');
     eventList.add('onResume');
   }
@@ -347,7 +347,7 @@ void main() {
 
       test('should record a span', () async {
         subs.add(tracer.onSpanFinish.listen(expectAsync1((span) {
-          expect(span.operationName, 'load_module');
+          expect(span.operationName, 'LifecycleModule.load');
           expect(span.tags['module.name'], 'TestLifecycleModule');
           expect(span.tags['custom.load.tag'], 'somevalue');
           expect(span.tags['error'], isNull);
@@ -375,7 +375,7 @@ void main() {
 
         test('should add the `error` span tag', () async {
           subs.add(tracer.onSpanFinish.listen(expectAsync1((span) {
-            expect(span.operationName, 'load_module');
+            expect(span.operationName, 'LifecycleModule.load');
             expect(span.tags['module.name'], 'TestLifecycleModule');
             expect(span.tags['error'], true);
           })));
@@ -750,7 +750,7 @@ void main() {
       test('should record a span', () async {
         await gotoState(module, LifecycleState.loaded);
         subs.add(tracer.onSpanFinish
-            .where((span) => span.operationName == 'suspend_module')
+            .where((span) => span.operationName == 'LifecycleModule.suspend')
             .listen((span) {
           expect(span.tags['custom.suspend.tag'], 'somevalue');
         }));
@@ -779,7 +779,7 @@ void main() {
         test('should add the `error` span tag', () async {
           await gotoState(module, LifecycleState.loaded);
           subs.add(tracer.onSpanFinish
-              .where((span) => span.operationName == 'suspend_module')
+              .where((span) => span.operationName == 'LifecycleModule.suspend')
               .listen(expectAsync1((span) {
             expect(span.tags['error'], true);
           })));
@@ -933,7 +933,7 @@ void main() {
         await gotoState(module, LifecycleState.suspended);
 
         subs.add(tracer.onSpanFinish
-            .where((span) => span.operationName == 'resume_module')
+            .where((span) => span.operationName == 'LifecycleModule.resume')
             .listen(expectAsync1((span) {
           expect(span.tags['custom.resume.tag'], 'somevalue');
         })));
@@ -961,7 +961,7 @@ void main() {
 
         test('should add the `error` span tag', () async {
           subs.add(tracer.onSpanFinish
-              .where((span) => span.operationName == 'resume_module')
+              .where((span) => span.operationName == 'LifecycleModule.resume')
               .listen(expectAsync1((span) {
             expect(span.tags['error'], true);
           })));
@@ -1356,7 +1356,7 @@ void main() {
 
       subs.add(tracer.onSpanFinish
           .where((span) =>
-              span.operationName == 'load_module' &&
+              span.operationName == 'LifecycleModule.load' &&
               span.tags['module.name'] == 'parent')
           .listen((span) {
         expect(parentSpanContext, isNull,
@@ -1545,7 +1545,7 @@ void main() {
       setUp(() async {
         subs.add(tracer.onSpanFinish
             .where((span) =>
-                span.operationName == 'suspend_module' &&
+                span.operationName == 'LifecycleModule.suspend' &&
                 span.tags['module.name'] == 'parent')
             .listen(expectAsync1((span) {
           parentSuspendContext = span.context;
@@ -1632,7 +1632,7 @@ void main() {
       setUp(() async {
         subs.add(tracer.onSpanFinish
             .where((span) =>
-                span.operationName == 'resume_module' &&
+                span.operationName == 'LifecycleModule.resume' &&
                 span.tags['module.name'] == 'parent')
             .listen(expectAsync1((span) {
           parentResumeContext = span.context;

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -1690,7 +1690,7 @@ void runTests(bool runSpanTests) {
                 throwsA(same(childModule.onSuspendError)));
 
             final span = await childSpanCompleter.future;
-            await new Future(() {}); // wait for parent to finish resuming
+            await new Future(() {}); // wait for parent to finish suspending
 
             expect(parentSuspendContext?.spanId, isNotNull);
             expect(span.parentContext.spanId, parentSuspendContext.spanId);
@@ -1797,7 +1797,7 @@ void runTests(bool runSpanTests) {
                 throwsA(same(childModule.onResumeError)));
 
             final span = await childSpanCompleter.future;
-            await new Future(() {}); // wait for parent to finish suspending
+            await new Future(() {}); // wait for parent to finish resuming
 
             expect(parentResumeContext?.spanId, isNotNull);
             expect(span.parentContext.spanId, parentResumeContext.spanId);

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -414,8 +414,7 @@ void runTests(bool runSpanTests) {
 
         if (runSpanTests) {
           test('should add the `error` span tag', () async {
-            subs.add(
-                getTestTracer().onSpanFinish.listen(expectAsync1((span) {
+            subs.add(getTestTracer().onSpanFinish.listen(expectAsync1((span) {
               expect(span.operationName, 'LifecycleModule.load');
               expect(span.tags['module.name'], 'TestLifecycleModule');
               expect(span.tags['error'], true);

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -18,10 +18,12 @@ import 'dart:async';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart' show protected;
 import 'package:mockito/mockito.dart';
+import 'package:opentracing/opentracing.dart';
 import 'package:test/test.dart';
 
 import 'package:w_module/src/lifecycle_module.dart';
 
+import 'test_tracer.dart';
 import 'utils.dart';
 
 const String shouldUnloadError = 'Mock shouldUnload false message';
@@ -135,6 +137,8 @@ class TestLifecycleModule extends LifecycleModule {
     if (onLoadError != null) {
       throw onLoadError;
     }
+    assert(activeSpan.operationName == 'load_module');
+    activeSpan.setTag('custom.load.tag', 'somevalue');
     eventList.add('onLoad');
   }
 
@@ -156,6 +160,8 @@ class TestLifecycleModule extends LifecycleModule {
     if (onUnloadError != null) {
       throw onUnloadError;
     }
+    assert(activeSpan.operationName == 'unload_module');
+    activeSpan.setTag('custom.unload.tag', 'somevalue');
     eventList.add('onUnload');
   }
 
@@ -166,6 +172,8 @@ class TestLifecycleModule extends LifecycleModule {
     if (onSuspendError != null) {
       throw onSuspendError;
     }
+    assert(activeSpan.operationName == 'suspend_module');
+    activeSpan.setTag('custom.suspend.tag', 'somevalue');
     eventList.add('onSuspend');
   }
 
@@ -176,6 +184,8 @@ class TestLifecycleModule extends LifecycleModule {
     if (onResumeError != null) {
       throw onResumeError;
     }
+    assert(activeSpan.operationName == 'resume_module');
+    activeSpan.setTag('custom.resume.tag', 'somevalue');
     eventList.add('onResume');
   }
 
@@ -281,8 +291,13 @@ void main() {
   Logger.root.level = Level.ALL;
   final StateError testError = new StateError('You should have expected this');
 
+  final TestTracer tracer = new TestTracer();
+  initGlobalTracer(tracer);
+  assert(globalTracer() == tracer);
+
   group('LifecycleModule', () {
     TestLifecycleModule module;
+    List<StreamSubscription> subs = [];
 
     setUp(() async {
       module = new TestLifecycleModule();
@@ -290,6 +305,8 @@ void main() {
 
     tearDown(() async {
       await module.tearDown();
+      subs.forEach((sub) => sub.cancel());
+      subs.clear();
     });
 
     void testInvalidTransitions(
@@ -330,6 +347,17 @@ void main() {
         await module.load();
       });
 
+      test('should record a span', () async {
+        subs.add(tracer.onSpanFinish.listen(expectAsync1((span) {
+          expect(span.operationName, 'load_module');
+          expect(span.tags['module.name'], 'TestLifecycleModule');
+          expect(span.tags['custom.load.tag'], 'somevalue');
+          expect(span.tags['error'], isNull);
+        })));
+
+        await module.load();
+      });
+
       group('with an onLoad that throws', () {
         setUp(() {
           module.onLoadError = testError;
@@ -344,6 +372,16 @@ void main() {
             expect(error, same(module.onLoadError));
             expect(stackTrace, isNotNull);
           }));
+          expect(module.load(), throwsA(same(module.onLoadError)));
+        });
+
+        test('should add the `error` span tag', () async {
+          subs.add(tracer.onSpanFinish.listen(expectAsync1((span) {
+            expect(span.operationName, 'load_module');
+            expect(span.tags['module.name'], 'TestLifecycleModule');
+            expect(span.tags['error'], true);
+          })));
+
           expect(module.load(), throwsA(same(module.onLoadError)));
         });
 
@@ -502,6 +540,20 @@ void main() {
         await module.unload();
       });
 
+      test('should record a span', () async {
+        await gotoState(module, LifecycleState.loaded);
+
+        subs.add(tracer.onSpanFinish
+            .where((span) => span.operationName == 'unload_module')
+            .listen(expectAsync1((span) {
+          expect(span.tags['module.name'], 'TestLifecycleModule');
+          expect(span.tags['custom.unload.tag'], 'somevalue');
+          expect(span.tags['error'], isNull);
+        })));
+
+        await module.unload();
+      });
+
       group('with an onUnload that throws', () {
         setUp(() async {
           await gotoState(module, LifecycleState.loaded);
@@ -511,7 +563,7 @@ void main() {
         });
 
         test('should return that error',
-            () => expect(module.unload(), throwsA(same(testError))));
+            () => expect(module.unload, throwsA(same(testError))));
 
         test('should add that error to didUnload stream', () {
           module.didUnload.listen((LifecycleModule _) {},
@@ -519,6 +571,16 @@ void main() {
             expect(error, same(module.onUnloadError));
             expect(stackTrace, isNotNull);
           }));
+          expect(module.unload(), throwsA(same(module.onUnloadError)));
+        });
+
+        test('should add the `error` span tag', () async {
+          subs.add(tracer.onSpanFinish
+              .where((span) => span.operationName == 'unload_module')
+              .listen(expectAsync1((span) {
+            expect(span.tags['error'], true);
+          })));
+
           expect(module.unload(), throwsA(same(module.onUnloadError)));
         });
 
@@ -711,6 +773,17 @@ void main() {
         await module.suspend();
       });
 
+      test('should record a span', () async {
+        await gotoState(module, LifecycleState.loaded);
+        subs.add(tracer.onSpanFinish
+            .where((span) => span.operationName == 'suspend_module')
+            .listen((span) {
+          expect(span.tags['custom.suspend.tag'], 'somevalue');
+        }));
+
+        await module.suspend();
+      });
+
       group('with an onSuspend that throws', () {
         setUp(() async {
           await gotoState(module, LifecycleState.loaded);
@@ -726,6 +799,17 @@ void main() {
             expect(error, same(module.onSuspendError));
             expect(stackTrace, isNotNull);
           }));
+          expect(module.suspend(), throwsA(same(module.onSuspendError)));
+        });
+
+        test('should add the `error` span tag', () async {
+          await gotoState(module, LifecycleState.loaded);
+          subs.add(tracer.onSpanFinish
+              .where((span) => span.operationName == 'suspend_module')
+              .listen(expectAsync1((span) {
+            expect(span.tags['error'], true);
+          })));
+
           expect(module.suspend(), throwsA(same(module.onSuspendError)));
         });
 
@@ -871,6 +955,18 @@ void main() {
         await module.resume();
       });
 
+      test('should record a span', () async {
+        await gotoState(module, LifecycleState.suspended);
+
+        subs.add(tracer.onSpanFinish
+            .where((span) => span.operationName == 'resume_module')
+            .listen(expectAsync1((span) {
+          expect(span.tags['custom.resume.tag'], 'somevalue');
+        })));
+
+        await module.resume();
+      });
+
       group('with an onResume that throws', () {
         setUp(() async {
           await gotoState(module, LifecycleState.suspended);
@@ -886,6 +982,16 @@ void main() {
             expect(error, same(module.onResumeError));
             expect(stackTrace, isNotNull);
           }));
+          expect(module.resume(), throwsA(same(module.onResumeError)));
+        });
+
+        test('should add the `error` span tag', () async {
+          subs.add(tracer.onSpanFinish
+              .where((span) => span.operationName == 'resume_module')
+              .listen(expectAsync1((span) {
+            expect(span.tags['error'], true);
+          })));
+
           expect(module.resume(), throwsA(same(module.onResumeError)));
         });
 
@@ -1267,16 +1373,34 @@ void main() {
   group('LifecycleModule with children', () {
     TestLifecycleModule childModule;
     TestLifecycleModule parentModule;
+    SpanContext parentSpanContext;
+    List<StreamSubscription> subs = [];
 
     setUp(() async {
       parentModule = new TestLifecycleModule(name: 'parent');
       childModule = new TestLifecycleModule(name: 'child');
+
+      subs.add(tracer.onSpanFinish
+          .where((span) =>
+              span.operationName == 'load_module' &&
+              span.tags['module.name'] == 'parent')
+          .listen((span) {
+        expect(parentSpanContext, isNull,
+            reason:
+                'parentSpanContext should only be set once because the parent module should only be loaded once.');
+
+        parentSpanContext = span.context;
+      }));
+
       await parentModule.load();
     });
 
     tearDown(() async {
       await parentModule.tearDown();
       await childModule.tearDown();
+      parentSpanContext = null;
+      subs.forEach((sub) => sub.cancel());
+      subs.clear();
     });
 
     group('loadChildModule', () {
@@ -1328,6 +1452,17 @@ void main() {
         await parentModule.loadChildModule(childModule);
       });
 
+      test('should record a span with `followsFrom` ref', () async {
+        subs.add(tracer.onSpanFinish
+            .where((span) => span.tags['module.name'] == 'child')
+            .listen(expectAsync1((span) {
+          expect(span.parentContext.spanId, parentSpanContext.spanId);
+          expect(span.tags['custom.load.tag'], 'somevalue');
+        })));
+
+        await parentModule.loadChildModule(childModule);
+      });
+
       group('with a child with an onLoad that throws', () {
         setUp(() {
           childModule.onLoadError = testError;
@@ -1344,6 +1479,19 @@ void main() {
             expect(error, same(childModule.onLoadError));
             expect(stackTrace, isNotNull);
           }));
+          expect(parentModule.loadChildModule(childModule),
+              throwsA(same(childModule.onLoadError)));
+        });
+
+        test('should record a span with `followsFrom` ref and `error` tag',
+            () async {
+          subs.add(tracer.onSpanFinish
+              .where((span) => span.tags['module.name'] == 'child')
+              .listen(expectAsync1((span) {
+            expect(span.parentContext.spanId, parentSpanContext.spanId);
+            expect(span.tags['error'], true);
+          })));
+
           expect(parentModule.loadChildModule(childModule),
               throwsA(same(childModule.onLoadError)));
         });
@@ -1418,11 +1566,31 @@ void main() {
     });
 
     group('suspend', () {
+      SpanContext parentSuspendContext;
+
       setUp(() async {
+        subs.add(tracer.onSpanFinish
+            .where((span) =>
+                span.operationName == 'suspend_module' &&
+                span.tags['module.name'] == 'parent')
+            .listen(expectAsync1((span) {
+          parentSuspendContext = span.context;
+        })));
+
         await parentModule.loadChildModule(childModule);
       });
 
+      tearDown(() {
+        parentSuspendContext = null;
+      });
+
       test('should suspend child modules', () async {
+        Completer<Span> childSpanCompleter = new Completer();
+
+        subs.add(tracer.onSpanFinish
+            .where((span) => span.tags['module.name'] == 'child')
+            .listen(expectAsync1(childSpanCompleter.complete)));
+
         parentModule.eventList.clear();
         childModule.eventList.clear();
         await parentModule.suspend();
@@ -1430,6 +1598,13 @@ void main() {
             equals(['willSuspend', 'onSuspend', 'didSuspend']));
         expect(childModule.eventList,
             equals(['willSuspend', 'onSuspend', 'didSuspend']));
+
+        final span = await childSpanCompleter.future;
+        await new Future(() {}); // wait for parent to finish suspending
+
+        assert(parentSuspendContext?.spanId != null);
+        expect(span.parentContext.spanId, parentSuspendContext.spanId);
+        expect(span.tags['custom.suspend.tag'], 'somevalue');
       });
 
       group('with a child with an onSuspend that throws', () {
@@ -1448,6 +1623,24 @@ void main() {
               throwsA(same(childModule.onSuspendError)));
         });
 
+        test('should add `error` span tag and `followsFrom` ref', () async {
+          Completer<Span> childSpanCompleter = new Completer();
+
+          subs.add(tracer.onSpanFinish
+              .where((span) => span.tags['module.name'] == 'child')
+              .listen(expectAsync1(childSpanCompleter.complete)));
+
+          expect(parentModule.suspend(),
+              throwsA(same(childModule.onSuspendError)));
+
+          final span = await childSpanCompleter.future;
+          await new Future(() {}); // wait for parent to finish suspending
+
+          assert(parentSuspendContext?.spanId != null);
+          expect(span.parentContext.spanId, parentSuspendContext.spanId);
+          expect(span.tags['error'], true);
+        });
+
         test('should still suspend other children', () async {
           var secondChildModule = new TestLifecycleModule();
           await parentModule.loadChildModule(secondChildModule);
@@ -1460,12 +1653,32 @@ void main() {
     });
 
     group('resume', () {
+      SpanContext parentResumeContext;
+
       setUp(() async {
+        subs.add(tracer.onSpanFinish
+            .where((span) =>
+                span.operationName == 'resume_module' &&
+                span.tags['module.name'] == 'parent')
+            .listen(expectAsync1((span) {
+          parentResumeContext = span.context;
+        })));
+
         await parentModule.loadChildModule(childModule);
         await parentModule.suspend();
       });
 
+      tearDown(() {
+        parentResumeContext = null;
+      });
+
       test('should resume child modules', () async {
+        Completer<Span> childSpanCompleter = new Completer();
+
+        subs.add(tracer.onSpanFinish
+            .where((span) => span.tags['module.name'] == 'child')
+            .listen(expectAsync1(childSpanCompleter.complete)));
+
         parentModule.eventList.clear();
         childModule.eventList.clear();
         await parentModule.resume();
@@ -1473,6 +1686,13 @@ void main() {
             equals(['willResume', 'onResume', 'didResume']));
         expect(childModule.eventList,
             equals(['willResume', 'onResume', 'didResume']));
+
+        final span = await childSpanCompleter.future;
+        await new Future(() {}); // wait for parent to finish resuming
+
+        assert(parentResumeContext?.spanId != null);
+        expect(span.parentContext.spanId, parentResumeContext.spanId);
+        expect(span.tags['custom.resume.tag'], 'somevalue');
       });
 
       group('with a child with an onResume that throws', () {
@@ -1489,6 +1709,24 @@ void main() {
                   expect(error, same(childModule.onResumeError))));
           expect(
               parentModule.resume(), throwsA(same(childModule.onResumeError)));
+        });
+
+        test('should add `error` span tag and `followsFrom` ref', () async {
+          Completer<Span> childSpanCompleter = new Completer();
+
+          subs.add(tracer.onSpanFinish
+              .where((span) => span.tags['module.name'] == 'child')
+              .listen(expectAsync1(childSpanCompleter.complete)));
+
+          expect(
+              parentModule.resume(), throwsA(same(childModule.onResumeError)));
+
+          final span = await childSpanCompleter.future;
+          await new Future(() {}); // wait for parent to finish suspending
+
+          assert(parentResumeContext?.spanId != null);
+          expect(span.parentContext.spanId, parentResumeContext.spanId);
+          expect(span.tags['error'], true);
         });
 
         test('should still resume other children', () async {

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -31,8 +31,14 @@ const String shouldUnloadError = 'Mock shouldUnload false message';
 class MockStreamSubscription extends Mock implements StreamSubscription<Null> {}
 
 class UnnamedModule extends LifecycleModule {
-  // This module does override the name getter
+  // This module does not override the name getter
   // so lifecycle methods should not create spans
+
+  // Overriding without re-applying the @protected annotation allows us to call
+  // loadChildModule in our tests below.
+  @override
+  Future<Null> loadChildModule(LifecycleModule newModule) =>
+      super.loadChildModule(newModule);
 }
 
 class TestLifecycleModule extends LifecycleModule {
@@ -57,7 +63,7 @@ class TestLifecycleModule extends LifecycleModule {
   List<String> eventList;
   bool mockShouldUnload;
 
-  TestLifecycleModule({String name}) : name = name ?? 'TestLifecycleModule' {
+  TestLifecycleModule({String name: 'TestLifecycleModule'}) : name = name {
     // init test validation data
     eventList = [];
     mockShouldUnload = true;
@@ -2307,6 +2313,148 @@ void runTests(bool runSpanTests) {
       expect(parentModule.eventList, equals(['onShouldUnload']));
       expect(childModule.eventList, equals(['onShouldUnload']));
     });
+  }, timeout: new Timeout(new Duration(seconds: 2)));
+
+  group('without name with children', () {
+    TestLifecycleModule childModule;
+    UnnamedModule parentModule;
+    List<StreamSubscription> subs = [];
+
+    setUp(() async {
+      parentModule = new UnnamedModule();
+      childModule = new TestLifecycleModule(name: 'child');
+
+      subs.add(getTestTracer()
+          .onSpanFinish
+          .where((span) => span.tags['module.name'] != 'child')
+          .listen((span) {
+        fail(
+            'Only the child module should have spans. Found: ${span.tags['module.name']}');
+      }));
+
+      await parentModule.load();
+    });
+
+    tearDown(() async {
+      await parentModule.dispose();
+      await childModule.tearDown();
+      subs.forEach((sub) => sub.cancel());
+      subs.clear();
+    });
+
+    if (runSpanTests) {
+      test('should record a span for child with no parent', () async {
+        subs.add(getTestTracer()
+            .onSpanFinish
+            .where((span) => span.operationName == 'LifecycleModule.load')
+            .where((span) => span.tags['module.name'] == 'child')
+            .listen(expectAsync1((span) {
+          expect(span.parentContext, isNull);
+          expect(span.tags['custom.load.tag'], 'somevalue');
+        })));
+
+        await parentModule.loadChildModule(childModule);
+      });
+
+      test('should record a span with `error` tag and no parent', () async {
+        childModule.onLoadError = testError;
+
+        subs.add(getTestTracer()
+            .onSpanFinish
+            .where((span) => span.operationName == 'LifecycleModule.load')
+            .where((span) => span.tags['module.name'] == 'child')
+            .listen(expectAsync1((span) {
+          expect(span.parentContext, isNull);
+          expect(span.tags['error'], true);
+        })));
+
+        expect(parentModule.loadChildModule(childModule),
+            throwsA(same(childModule.onLoadError)));
+      });
+
+      test('child module suspend should record spans with no parent', () async {
+        await parentModule.loadChildModule(childModule);
+        subs.add(getTestTracer()
+            .onSpanFinish
+            .where((span) => span.operationName == 'LifecycleModule.suspend')
+            .where((span) => span.tags['module.name'] == 'child')
+            .listen(expectAsync1((span) {
+          expect(span.parentContext, isNull);
+          expect(span.tags['custom.suspend.tag'], 'somevalue');
+        })));
+
+        await parentModule.suspend();
+      });
+
+      test(
+          'child module suspend throws should record a span with `error` tag and no parent',
+          () async {
+        await parentModule.loadChildModule(childModule);
+        childModule.onSuspendError = testError;
+
+        subs.add(getTestTracer()
+            .onSpanFinish
+            .where((span) => span.operationName == 'LifecycleModule.suspend')
+            .where((span) => span.tags['module.name'] == 'child')
+            .listen(expectAsync1((span) {
+          expect(span.parentContext, isNull);
+          expect(span.tags['error'], true);
+        })));
+
+        expect(
+            parentModule.suspend(), throwsA(same(childModule.onSuspendError)));
+      });
+
+      test('child module resume should record a span with no parent', () async {
+        await parentModule.loadChildModule(childModule);
+
+        subs.add(getTestTracer()
+            .onSpanFinish
+            .where((span) => span.operationName == 'LifecycleModule.resume')
+            .where((span) => span.tags['module.name'] == 'child')
+            .listen(expectAsync1((span) {
+          expect(span.parentContext, isNull);
+          expect(span.tags['custom.resume.tag'], 'somevalue');
+        })));
+
+        await gotoState(parentModule, LifecycleState.suspended);
+        await parentModule.resume();
+      });
+
+      test(
+          'child module resume should record a span with `error` tag and no parent',
+          () async {
+        await parentModule.loadChildModule(childModule);
+        childModule.onResumeError = testError;
+
+        subs.add(getTestTracer()
+            .onSpanFinish
+            .where((span) => span.operationName == 'LifecycleModule.resume')
+            .where((span) => span.tags['module.name'] == 'child')
+            .listen(expectAsync1((span) {
+          expect(span.parentContext, isNull);
+          expect(span.tags['error'], true);
+        })));
+
+        await gotoState(parentModule, LifecycleState.suspended);
+        expect(parentModule.resume(), throwsA(same(childModule.onResumeError)));
+      });
+
+      test('should record a span on unload', () async {
+        await parentModule.loadChildModule(childModule);
+
+        subs.add(getTestTracer()
+            .onSpanFinish
+            .where((span) => span.operationName == 'LifecycleModule.unload')
+            .where((span) => span.tags['module.name'] == 'child')
+            .listen(expectAsync1((span) {
+          expect(span.parentContext, isNull);
+          expect(span.tags['custom.unload.tag'], 'somevalue');
+        })));
+
+        await parentModule.unload();
+      });
+    }
   }, timeout: new Timeout(new Duration(seconds: 2)));
 
   group('shouldUnloadResult', () {

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -323,7 +323,7 @@ void main() {
 }
 
 /// Returns the `globalTracer()` typecasted as a `TestTracer` or `null`.
-TestTracer globalTestTracer() {
+TestTracer getTestTracer() {
   // Type cast here or return null
   TestTracer tracer = globalTracer();
   return tracer;
@@ -384,7 +384,7 @@ void runTests(bool runSpanTests) {
 
       if (runSpanTests) {
         test('should record a span', () async {
-          subs.add(globalTestTracer().onSpanFinish.listen(expectAsync1((span) {
+          subs.add(getTestTracer().onSpanFinish.listen(expectAsync1((span) {
             expect(span.operationName, 'LifecycleModule.load');
             expect(span.tags['module.name'], 'TestLifecycleModule');
             expect(span.tags['custom.load.tag'], 'somevalue');
@@ -415,7 +415,7 @@ void runTests(bool runSpanTests) {
         if (runSpanTests) {
           test('should add the `error` span tag', () async {
             subs.add(
-                globalTestTracer().onSpanFinish.listen(expectAsync1((span) {
+                getTestTracer().onSpanFinish.listen(expectAsync1((span) {
               expect(span.operationName, 'LifecycleModule.load');
               expect(span.tags['module.name'], 'TestLifecycleModule');
               expect(span.tags['error'], true);
@@ -792,7 +792,7 @@ void runTests(bool runSpanTests) {
       if (runSpanTests) {
         test('should record a span', () async {
           await gotoState(module, LifecycleState.loaded);
-          subs.add(globalTestTracer()
+          subs.add(getTestTracer()
               .onSpanFinish
               .where((span) => span.operationName == 'LifecycleModule.suspend')
               .listen((span) {
@@ -824,7 +824,7 @@ void runTests(bool runSpanTests) {
         if (runSpanTests) {
           test('should add the `error` span tag', () async {
             await gotoState(module, LifecycleState.loaded);
-            subs.add(globalTestTracer()
+            subs.add(getTestTracer()
                 .onSpanFinish
                 .where(
                     (span) => span.operationName == 'LifecycleModule.suspend')
@@ -982,7 +982,7 @@ void runTests(bool runSpanTests) {
         test('should record a span', () async {
           await gotoState(module, LifecycleState.suspended);
 
-          subs.add(globalTestTracer()
+          subs.add(getTestTracer()
               .onSpanFinish
               .where((span) => span.operationName == 'LifecycleModule.resume')
               .listen(expectAsync1((span) {
@@ -1013,7 +1013,7 @@ void runTests(bool runSpanTests) {
 
         if (runSpanTests) {
           test('should add the `error` span tag', () async {
-            subs.add(globalTestTracer()
+            subs.add(getTestTracer()
                 .onSpanFinish
                 .where((span) => span.operationName == 'LifecycleModule.resume')
                 .listen(expectAsync1((span) {
@@ -1410,7 +1410,7 @@ void runTests(bool runSpanTests) {
       childModule = new TestLifecycleModule(name: 'child');
 
       if (runSpanTests) {
-        subs.add(globalTestTracer()
+        subs.add(getTestTracer()
             .onSpanFinish
             .where((span) =>
                 span.operationName == 'LifecycleModule.load' &&
@@ -1486,7 +1486,7 @@ void runTests(bool runSpanTests) {
 
       if (runSpanTests) {
         test('should record a span with `followsFrom` ref', () async {
-          subs.add(globalTestTracer()
+          subs.add(getTestTracer()
               .onSpanFinish
               .where((span) => span.tags['module.name'] == 'child')
               .listen(expectAsync1((span) {
@@ -1521,7 +1521,7 @@ void runTests(bool runSpanTests) {
         if (runSpanTests) {
           test('should record a span with `followsFrom` ref and `error` tag',
               () async {
-            subs.add(globalTestTracer()
+            subs.add(getTestTracer()
                 .onSpanFinish
                 .where((span) => span.operationName == 'LifecycleModule.load')
                 .listen(expectAsync1((span) {
@@ -1608,7 +1608,7 @@ void runTests(bool runSpanTests) {
 
       setUp(() async {
         if (runSpanTests) {
-          subs.add(globalTestTracer()
+          subs.add(getTestTracer()
               .onSpanFinish
               .where((span) =>
                   span.operationName == 'LifecycleModule.suspend' &&
@@ -1639,7 +1639,7 @@ void runTests(bool runSpanTests) {
         test('child module suspends should record spans', () async {
           Completer<Span> childSpanCompleter = new Completer();
 
-          subs.add(globalTestTracer()
+          subs.add(getTestTracer()
               .onSpanFinish
               .where((span) => span.tags['module.name'] == 'child')
               .listen(expectAsync1(childSpanCompleter.complete)));
@@ -1681,7 +1681,7 @@ void runTests(bool runSpanTests) {
           test('should add `error` span tag and `followsFrom` ref', () async {
             Completer<Span> childSpanCompleter = new Completer();
 
-            subs.add(globalTestTracer()
+            subs.add(getTestTracer()
                 .onSpanFinish
                 .where((span) => span.tags['module.name'] == 'child')
                 .listen(expectAsync1(childSpanCompleter.complete)));
@@ -1690,7 +1690,7 @@ void runTests(bool runSpanTests) {
                 throwsA(same(childModule.onSuspendError)));
 
             final span = await childSpanCompleter.future;
-            await new Future(() {}); // wait for parent to finish suspending
+            await new Future(() {}); // wait for parent to finish resuming
 
             expect(parentSuspendContext?.spanId, isNotNull);
             expect(span.parentContext.spanId, parentSuspendContext.spanId);
@@ -1714,7 +1714,7 @@ void runTests(bool runSpanTests) {
 
       setUp(() async {
         if (runSpanTests) {
-          subs.add(globalTestTracer()
+          subs.add(getTestTracer()
               .onSpanFinish
               .where((span) =>
                   span.operationName == 'LifecycleModule.resume' &&
@@ -1746,7 +1746,7 @@ void runTests(bool runSpanTests) {
         test('child module resumes should record spans', () async {
           Completer<Span> childSpanCompleter = new Completer();
 
-          subs.add(globalTestTracer()
+          subs.add(getTestTracer()
               .onSpanFinish
               .where((span) => span.tags['module.name'] == 'child')
               .listen(expectAsync1(childSpanCompleter.complete)));
@@ -1788,7 +1788,7 @@ void runTests(bool runSpanTests) {
           test('should add `error` span tag and `followsFrom` ref', () async {
             Completer<Span> childSpanCompleter = new Completer();
 
-            subs.add(globalTestTracer()
+            subs.add(getTestTracer()
                 .onSpanFinish
                 .where((span) => span.tags['module.name'] == 'child')
                 .listen(expectAsync1(childSpanCompleter.complete)));
@@ -1821,7 +1821,7 @@ void runTests(bool runSpanTests) {
 
       setUp(() async {
         if (runSpanTests) {
-          subs.add(globalTestTracer()
+          subs.add(getTestTracer()
               .onSpanFinish
               .where((span) =>
                   span.operationName == 'LifecycleModule.unload' &&
@@ -1872,7 +1872,7 @@ void runTests(bool runSpanTests) {
 
           Completer<Span> childSpanCompleter = new Completer();
 
-          subs.add(globalTestTracer()
+          subs.add(getTestTracer()
               .onSpanFinish
               .where((span) => span.tags['module.name'] == 'child')
               .listen(expectAsync1(childSpanCompleter.complete)));

--- a/test/test_tracer.dart
+++ b/test/test_tracer.dart
@@ -1,0 +1,166 @@
+import 'dart:async';
+import 'package:opentracing/opentracing.dart';
+
+class TestSpan implements Span {
+  static int _nextId = 0;
+  final int _id = _nextId++;
+
+  @override
+  final List<Reference> references;
+
+  @override
+  final Map<String, dynamic> tags;
+
+  @override
+  final List<LogData> logData = [];
+
+  @override
+  final String operationName;
+
+  @override
+  SpanContext context;
+
+  @override
+  final DateTime startTime;
+  DateTime _endTime;
+
+  Completer<Span> _whenFinished = new Completer<Span>();
+
+  TestSpan(
+    this.operationName, {
+    SpanContext childOf,
+    List<Reference> references,
+    DateTime startTime,
+    Map<String, dynamic> tags,
+  })
+      : this.startTime = startTime ?? new DateTime.now(),
+        this.tags = tags ?? {},
+        this.references = references ?? {} {
+    if (childOf != null) {
+      references.add(new Reference.childOf(childOf));
+    }
+    setTag('span.kind', 'client');
+
+    final parent = parentContext;
+    if (parent != null) {
+      this.context = new SpanContext(spanId: _id, traceId: parent.traceId);
+      this.context.baggage.addAll(parent.baggage);
+    } else {
+      this.context = new SpanContext(spanId: _id, traceId: _id);
+    }
+  }
+
+  @override
+  void addTags(Map<String, dynamic> newTags) => tags.addAll(newTags);
+
+  @override
+  Duration get duration => _endTime?.difference(startTime);
+
+  @override
+  DateTime get endTime => _endTime;
+
+  @override
+  void finish({DateTime finishTime}) {
+    if (_whenFinished == null) {
+      return;
+    }
+
+    _endTime = finishTime ?? new DateTime.now();
+    _whenFinished.complete(this);
+    _whenFinished = null;
+  }
+
+  @override
+  void log(String event, {dynamic payload, DateTime timestamp}) =>
+      logData.add(new LogData(timestamp ?? new DateTime.now(), event, payload));
+
+  @override
+  SpanContext get parentContext =>
+      references.isEmpty ? null : references.first.referencedContext;
+
+  @override
+  void setTag(String tagName, dynamic value) => tags[tagName] = value;
+
+  @override
+  Future<Span> get whenFinished => _whenFinished.future;
+
+  @override
+  String toString() {
+    final sb = new StringBuffer('SampleSpan(');
+    sb
+      ..writeln('traceId: ${context.traceId}')
+      ..writeln('spanId: ${context.spanId}')
+      ..writeln('operationName: $operationName')
+      ..writeln('tags: ${tags.toString()}')
+      ..writeln('startTime: ${startTime.toString()}');
+
+    if (_endTime != null) {
+      sb
+        ..writeln('endTime: ${endTime.toString()}')
+        ..writeln('duration: ${duration.toString()}');
+    }
+
+    if (logData.isNotEmpty) {
+      sb.writeln('logData: ${logData.toString()}');
+    }
+
+    if (references.isNotEmpty) {
+      final reference = references.first;
+      sb.writeln(
+          'reference: ${reference.referenceType} ${reference.referencedContext.spanId}');
+    }
+
+    sb.writeln(')');
+
+    return sb.toString();
+  }
+}
+
+class TestTracer implements AbstractTracer {
+  // There should only ever be one of these
+  // ignore: close_sinks
+  StreamController<Span> _finishController = new StreamController.broadcast();
+
+  Stream<Span> get onSpanFinish => _finishController.stream;
+
+  @override
+  TestSpan startSpan(
+    String operationName, {
+    SpanContext childOf,
+    List<Reference> references,
+    DateTime startTime,
+    Map<String, dynamic> tags,
+  }) {
+    return new TestSpan(
+      operationName,
+      childOf: childOf,
+      references: references,
+      startTime: startTime,
+      tags: tags,
+    )..whenFinished.then(_finishController.add);
+  }
+
+  @override
+  Reference childOf(SpanContext context) => new Reference.childOf(context);
+
+  @override
+  Reference followsFrom(SpanContext context) =>
+      new Reference.followsFrom(context);
+
+  @override
+  SpanContext extract(String format, dynamic carrier) {
+    throw new UnimplementedError(
+        'Sample tracer for example purposes does not support advanced tracing behavior.');
+  }
+
+  @override
+  void inject(SpanContext spanContext, String format, dynamic carrier) {
+    throw new UnimplementedError(
+        'Sample tracer for example purposes does not support advanced tracing behavior.');
+  }
+
+  @override
+  Future<dynamic> flush() {
+    return null;
+  }
+}


### PR DESCRIPTION
# Description

Pretty much every module could benefit from added tracing, especially if it comes free to consumers.

# Changes

- If a `globalTracer()` is configured for the application, create a span for each of the lifecycle transitions and expose it to consumers who may wish to apply additional tags or use it for `childOf` and `followsFrom` references to other tags.
- Pass on the `SpanContext` from the transition span to any child modules so their transitions have a `childOf` link back to this one.

# Testing

Play with the example and note the console logging.