### PR TITLE
AF-1541 additional timing granularity

### DIFF
--- a/example/panel/modules/data_load_async_module.dart
+++ b/example/panel/modules/data_load_async_module.dart
@@ -44,7 +44,8 @@ class DataLoadAsyncModule extends Module {
   @protected
   Future<Null> onLoad() {
     // trigger non-blocking async load of data
-    _events.didLoadData.first.then((_) => didEnterFirstUsefulState());
+    _events.didLoadData.first
+        .then((_) => specifyStartupTiming(StartupTimingSpecifier.firstUseful));
     _actions.loadData();
     return null;
   }

--- a/example/panel/modules/data_load_async_module.dart
+++ b/example/panel/modules/data_load_async_module.dart
@@ -44,9 +44,9 @@ class DataLoadAsyncModule extends Module {
   @protected
   Future<Null> onLoad() {
     // trigger non-blocking async load of data
-    _actions.loadData();
     _events.didLoadData.first.then((_) => didEnterFirstUsefulState());
-    return new Future.value();
+    _actions.loadData();
+    return null;
   }
 }
 

--- a/example/panel/modules/data_load_async_module.dart
+++ b/example/panel/modules/data_load_async_module.dart
@@ -27,12 +27,14 @@ class DataLoadAsyncModule extends Module {
 
   DataLoadAsyncActions _actions;
   DataLoadAsyncComponents _components;
-  DataLoadAsyncStore _stores;
+  DataLoadAsyncEvents _events;
+  DataLoadAsyncStore _store;
 
   DataLoadAsyncModule() {
     _actions = new DataLoadAsyncActions();
-    _stores = new DataLoadAsyncStore(_actions);
-    _components = new DataLoadAsyncComponents(_actions, _stores);
+    _events = new DataLoadAsyncEvents();
+    _store = new DataLoadAsyncStore(_actions, _events);
+    _components = new DataLoadAsyncComponents(_actions, _store);
   }
 
   @override
@@ -43,6 +45,7 @@ class DataLoadAsyncModule extends Module {
   Future<Null> onLoad() {
     // trigger non-blocking async load of data
     _actions.loadData();
+    _events.didLoadData.first.then((_) => didEnterFirstUsefulState());
     return new Future.value();
   }
 }
@@ -62,15 +65,20 @@ class DataLoadAsyncActions {
   final Action loadData = new Action();
 }
 
+DispatchKey _dispatchKey = new DispatchKey('DataLoadAsync');
+
+class DataLoadAsyncEvents {
+  final Event didLoadData = new Event(_dispatchKey);
+}
+
 class DataLoadAsyncStore extends Store {
   DataLoadAsyncActions _actions;
-  List<String> _data;
-  bool _isLoading;
+  DataLoadAsyncEvents _events;
+  List<String> _data = [];
+  bool _isLoading = false;
 
-  DataLoadAsyncStore(this._actions) {
-    _isLoading = false;
-    _data = [];
-    triggerOnAction(_actions.loadData, _loadData);
+  DataLoadAsyncStore(this._actions, this._events) {
+    manageActionSubscription(_actions.loadData.listen(_loadData));
   }
 
   /// Public data
@@ -89,6 +97,8 @@ class DataLoadAsyncStore extends Store {
     // trigger on return of final data
     _data = ['Aaron', 'Dustin', 'Evan', 'Jay', 'Max', 'Trent'];
     _isLoading = false;
+    _events.didLoadData(null, _dispatchKey);
+    trigger();
   }
 }
 

--- a/example/panel/modules/sample_tracer.dart
+++ b/example/panel/modules/sample_tracer.dart
@@ -1,0 +1,162 @@
+import 'dart:async';
+import 'package:opentracing/opentracing.dart';
+
+class SampleSpan implements Span {
+  static int _nextId = 0;
+  final int _id = _nextId++;
+
+  @override
+  final List<Reference> references;
+
+  @override
+  final Map<String, dynamic> tags;
+
+  @override
+  final List<LogData> logData = [];
+
+  @override
+  final String operationName;
+
+  @override
+  SpanContext context;
+
+  @override
+  final DateTime startTime;
+  DateTime _endTime;
+
+  Completer<Span> _whenFinished = new Completer<Span>();
+
+  SampleSpan(
+    this.operationName, {
+    SpanContext childOf,
+    this.references,
+    DateTime startTime,
+    Map<String, dynamic> tags,
+  })
+      : this.startTime = startTime ?? new DateTime.now(),
+        this.tags = tags ?? {} {
+    if (childOf != null) {
+      references.add(new Reference.childOf(childOf));
+    }
+    setTag('span.kind', 'client');
+
+    final parent = parentContext;
+    if (parent != null) {
+      this.context = new SpanContext(spanId: _id, traceId: parent.traceId);
+      this.context.baggage.addAll(parent.baggage);
+    } else {
+      this.context = new SpanContext(spanId: _id, traceId: _id);
+    }
+  }
+
+  @override
+  void addTags(Map<String, dynamic> newTags) => tags.addAll(newTags);
+
+  @override
+  Duration get duration => _endTime?.difference(startTime);
+
+  @override
+  DateTime get endTime => _endTime;
+
+  @override
+  void finish({DateTime finishTime}) {
+    if (_whenFinished == null) {
+      return;
+    }
+
+    _endTime = finishTime ?? new DateTime.now();
+    _whenFinished.complete(this);
+    _whenFinished = null;
+  }
+
+  @override
+  void log(String event, {dynamic payload, DateTime timestamp}) =>
+      logData.add(new LogData(timestamp ?? new DateTime.now(), event, payload));
+
+  @override
+  SpanContext get parentContext =>
+      references.isEmpty ? null : references.first.referencedContext;
+
+  @override
+  void setTag(String tagName, dynamic value) => tags[tagName] = value;
+
+  @override
+  Future<Span> get whenFinished => _whenFinished.future;
+
+  @override
+  String toString() {
+    final sb = new StringBuffer('SampleSpan(');
+    sb
+      ..writeln('traceId: ${context.traceId}')
+      ..writeln('spanId: ${context.spanId}')
+      ..writeln('operationName: $operationName')
+      ..writeln('tags: ${tags.toString()}')
+      ..writeln('startTime: ${startTime.toString()}');
+
+    if (_endTime != null) {
+      sb
+        ..writeln('endTime: ${endTime.toString()}')
+        ..writeln('duration: ${duration.toString()}');
+    }
+
+    if (logData.isNotEmpty) {
+      sb.writeln('logData: ${logData.toString()}');
+    }
+
+    if (references.isNotEmpty) {
+      final reference = references.first;
+      sb.writeln(
+          'reference: ${reference.referenceType} ${reference.referencedContext.spanId}');
+    }
+
+    sb.writeln(')');
+
+    return sb.toString();
+  }
+}
+
+class SampleTracer implements AbstractTracer {
+  @override
+  SampleSpan startSpan(
+    String operationName, {
+    SpanContext childOf,
+    List<Reference> references,
+    DateTime startTime,
+    Map<String, dynamic> tags,
+  }) {
+    return new SampleSpan(
+      operationName,
+      childOf: childOf,
+      references: references,
+      startTime: startTime,
+      tags: tags,
+    )
+      ..whenFinished.then((span) {
+        print(span.toString());
+      });
+  }
+
+  @override
+  Reference childOf(SpanContext context) => new Reference.childOf(context);
+
+  @override
+  Reference followsFrom(SpanContext context) =>
+      new Reference.followsFrom(context);
+
+  @override
+  SpanContext extract(String format, dynamic carrier) {
+    throw new UnimplementedError(
+        'Sample tracer for example purposes does not support advanced tracing behavior.');
+  }
+
+  @override
+  void inject(SpanContext spanContext, String format, dynamic carrier) {
+    throw new UnimplementedError(
+        'Sample tracer for example purposes does not support advanced tracing behavior.');
+  }
+
+  @override
+  Future<dynamic> flush() {
+    return null;
+  }
+}

--- a/example/panel/panel_app.dart
+++ b/example/panel/panel_app.dart
@@ -22,12 +22,18 @@ import 'package:platform_detect/platform_detect.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart' as react_client;
 import 'package:w_module/w_module.dart' hide Event;
+import 'package:opentracing/opentracing.dart';
 
 import 'modules/panel_module.dart';
+import 'modules/sample_tracer.dart';
 
 Future<Null> main() async {
   Element container = querySelector('#panel-container');
   react_client.setClientConfiguration();
+
+  final tracer = new SampleTracer();
+  initGlobalTracer(tracer);
+  assert(globalTracer() == tracer);
 
   // instantiate the core app module and wait for it to complete loading
   PanelModule panelModule = new PanelModule();

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -22,6 +22,7 @@ import 'package:opentracing/opentracing.dart';
 import 'package:w_common/disposable.dart';
 
 import 'package:w_module/src/simple_module.dart';
+import 'package:w_module/src/timing_specifiers.dart';
 
 /// Possible states a [LifecycleModule] may occupy.
 enum LifecycleState {
@@ -178,7 +179,10 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   /// only be started in [onLoad].
   ///
   /// Any [tags] specified will be added to the span which results from this call.
-  void didEnterFirstUsefulState({Map<String, dynamic> tags: const {}}) {
+  void specifyStartupTiming(
+    StartupTimingSpecifier specifier, {
+    Map<String, dynamic> tags: const {},
+  }) {
     // Load didn't start
     if (_loadContext == null || _startLoadTime == null) {
       return null;
@@ -191,7 +195,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
 
     tracer
         .startSpan(
-          'module_entered_first_useful_state',
+          specifier.name,
           references: [tracer.followsFrom(_loadContext)],
           startTime: _startLoadTime,
           tags: _defaultTags..addAll(tags),

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -400,10 +400,9 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
           reason: 'A module can only be loaded once.');
     }
 
-    _startLoadTime = new DateTime.now();
-
     _activeSpan = _startTransitionSpan('load_module');
     _loadContext = _activeSpan.context;
+    _startLoadTime = _activeSpan.startTime;
 
     _state = LifecycleState.loading;
 

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -347,7 +347,6 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
           reason: 'A module can only be loaded once.');
     }
 
-    // TODO childOf or followsFrom
     _span = _startTransitionSpan('load($name)');
 
     _state = LifecycleState.loading;

--- a/lib/src/timing_specifiers.dart
+++ b/lib/src/timing_specifiers.dart
@@ -1,0 +1,16 @@
+class StartupTimingSpecifier {
+  final String name;
+  const StartupTimingSpecifier._(this.name);
+
+  static const StartupTimingSpecifier firstComponentRender =
+      const StartupTimingSpecifier._('module_first_component_rendered');
+
+  static const StartupTimingSpecifier firstEditable =
+      const StartupTimingSpecifier._('module_entered_first_editable_state');
+
+  static const StartupTimingSpecifier firstReadable =
+      const StartupTimingSpecifier._('module_entered_first_readable_state');
+
+  static const StartupTimingSpecifier firstUseful =
+      const StartupTimingSpecifier._('module_entered_first_useful_state');
+}

--- a/lib/w_module.dart
+++ b/lib/w_module.dart
@@ -26,3 +26,4 @@ export 'package:w_module/src/events_collection.dart';
 export 'package:w_module/src/lifecycle_module.dart' hide LifecycleState;
 export 'package:w_module/src/module.dart';
 export 'package:w_module/src/simple_module.dart';
+export 'package:w_module/src/timing_specifiers.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   logging: ^0.11.0
   meta: ^1.0.0
   platform_detect: ^1.1.0
+  opentracing: ^0.2.1
   w_common: ^1.9.0
 
 dev_dependencies:
@@ -23,7 +24,6 @@ dev_dependencies:
   dart_style: ^0.2.16
   dartdoc: ^0.9.0
   mockito: ^1.0.1
-  opentracing: ^0.2.1
   react: ^3.0.0
   test: ^0.12.0
   w_flux: '>=1.0.0 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dev_dependencies:
   dart_style: ^0.2.16
   dartdoc: ^0.9.0
   mockito: ^1.0.1
+  opentracing: ^0.2.1
   react: ^3.0.0
   test: ^0.12.0
   w_flux: '>=1.0.0 <3.0.0'

--- a/test/test_tracer.dart
+++ b/test/test_tracer.dart
@@ -1,0 +1,166 @@
+import 'dart:async';
+import 'package:opentracing/opentracing.dart';
+
+class TestSpan implements Span {
+  static int _nextId = 0;
+  final int _id = _nextId++;
+
+  @override
+  final List<Reference> references;
+
+  @override
+  final Map<String, dynamic> tags;
+
+  @override
+  final List<LogData> logData = [];
+
+  @override
+  final String operationName;
+
+  @override
+  SpanContext context;
+
+  @override
+  final DateTime startTime;
+  DateTime _endTime;
+
+  Completer<Span> _whenFinished = new Completer<Span>();
+
+  TestSpan(
+    this.operationName, {
+    SpanContext childOf,
+    List<Reference> references,
+    DateTime startTime,
+    Map<String, dynamic> tags,
+  })
+      : this.startTime = startTime ?? new DateTime.now(),
+        this.tags = tags ?? {},
+        this.references = references ?? {} {
+    if (childOf != null) {
+      references.add(new Reference.childOf(childOf));
+    }
+    setTag('span.kind', 'client');
+
+    final parent = parentContext;
+    if (parent != null) {
+      this.context = new SpanContext(spanId: _id, traceId: parent.traceId);
+      this.context.baggage.addAll(parent.baggage);
+    } else {
+      this.context = new SpanContext(spanId: _id, traceId: _id);
+    }
+  }
+
+  @override
+  void addTags(Map<String, dynamic> newTags) => tags.addAll(newTags);
+
+  @override
+  Duration get duration => _endTime?.difference(startTime);
+
+  @override
+  DateTime get endTime => _endTime;
+
+  @override
+  void finish({DateTime finishTime}) {
+    if (_whenFinished == null) {
+      return;
+    }
+
+    _endTime = finishTime ?? new DateTime.now();
+    _whenFinished.complete(this);
+    _whenFinished = null;
+  }
+
+  @override
+  void log(String event, {dynamic payload, DateTime timestamp}) =>
+      logData.add(new LogData(timestamp ?? new DateTime.now(), event, payload));
+
+  @override
+  SpanContext get parentContext =>
+      references.isEmpty ? null : references.first.referencedContext;
+
+  @override
+  void setTag(String tagName, dynamic value) => tags[tagName] = value;
+
+  @override
+  Future<Span> get whenFinished => _whenFinished.future;
+
+  @override
+  String toString() {
+    final sb = new StringBuffer('SampleSpan(');
+    sb
+      ..writeln('traceId: ${context.traceId}')
+      ..writeln('spanId: ${context.spanId}')
+      ..writeln('operationName: $operationName')
+      ..writeln('tags: ${tags.toString()}')
+      ..writeln('startTime: ${startTime.toString()}');
+
+    if (_endTime != null) {
+      sb
+        ..writeln('endTime: ${endTime.toString()}')
+        ..writeln('duration: ${duration.toString()}');
+    }
+
+    if (logData.isNotEmpty) {
+      sb.writeln('logData: ${logData.toString()}');
+    }
+
+    if (references.isNotEmpty) {
+      final reference = references.first;
+      sb.writeln(
+          'reference: ${reference.referenceType} ${reference.referencedContext.spanId}');
+    }
+
+    sb.writeln(')');
+
+    return sb.toString();
+  }
+}
+
+class TestTracer implements AbstractTracer {
+  // There should only ever be one of these
+  // ignore: close_sinks
+  StreamController<Span> _finishController = new StreamController.broadcast();
+
+  Stream<Span> get onSpanFinish => _finishController.stream;
+
+  @override
+  TestSpan startSpan(
+    String operationName, {
+    SpanContext childOf,
+    List<Reference> references,
+    DateTime startTime,
+    Map<String, dynamic> tags,
+  }) {
+    return new TestSpan(
+      operationName,
+      childOf: childOf,
+      references: references,
+      startTime: startTime,
+      tags: tags,
+    )..whenFinished.then(_finishController.add);
+  }
+
+  @override
+  Reference childOf(SpanContext context) => new Reference.childOf(context);
+
+  @override
+  Reference followsFrom(SpanContext context) =>
+      new Reference.followsFrom(context);
+
+  @override
+  SpanContext extract(String format, dynamic carrier) {
+    throw new UnimplementedError(
+        'Sample tracer for example purposes does not support advanced tracing behavior.');
+  }
+
+  @override
+  void inject(SpanContext spanContext, String format, dynamic carrier) {
+    throw new UnimplementedError(
+        'Sample tracer for example purposes does not support advanced tracing behavior.');
+  }
+
+  @override
+  Future<dynamic> flush() {
+    return null;
+  }
+}


### PR DESCRIPTION
# Note

Merges #115. Clean diff: https://github.com/Workiva/w_module/compare/AF-1540_consumer-specified-timing...AF-1541_additional-timing-granularity

It will result in a breaking API change if they are merged separately. Handle this before merging either this or that, or merge together.

## Description

There are other useful startup time properties that would be nice to measure. Allow consumers to call a method with a specifier for which timing operation this is.

## Testing

See the `DataLoadAsync` example.