### PR TITLE
AF-1961 Deprecate serializable_module.dart entry point

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-  - stable
+  - 1.24.3
 script:
   - pub get --packages-dir
   - pub run dart_dev format --check

--- a/lib/serializable_module.dart
+++ b/lib/serializable_module.dart
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// Deprecated: 1.6.0
+/// To be removed: 2.0.0
+///
+/// The serializable module classes rely on `dart:mirrors`, which are no longer
+/// supported in the browser in Dart 2.
+@deprecated
 library serializable_module;
 
 export 'package:w_module/src/serializable.dart';


### PR DESCRIPTION
## Description
The `serializable_module.dart` entry point needs to be removed for Dart 2 compatibility. That will happen in a major release, which means we need to deprecate it in our current major line first.

## Code Review
@Workiva/app-frameworks 
@robbecker-wf 