### PR TITLE
AF-2735 memory leak with tracing

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -1004,6 +1004,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       rethrow;
     } finally {
       _activeSpan?.finish();
+      _activeSpan = null;
     }
   }
 }

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -100,6 +100,11 @@ class TestLifecycleModule extends LifecycleModule {
   }
 
   // Overriding without re-applying the @protected annotation allows us to call
+  // activeSpan in our tests below.
+  @override
+  Span get activeSpan => super.activeSpan;
+
+  // Overriding without re-applying the @protected annotation allows us to call
   // loadChildModule in our tests below.
   @override
   Future<Null> loadChildModule(LifecycleModule newModule) =>
@@ -402,6 +407,11 @@ void runTests(bool runSpanTests) {
           })));
 
           await module.load();
+        });
+
+        test('activeSpan should be null when load is finished', () async {
+          await module.load();
+          expect(module.activeSpan, isNull);
         });
       }
 
@@ -785,6 +795,7 @@ void runTests(bool runSpanTests) {
             ['willResume', 'onResume', 'didResume']
               ..addAll(expectedSuspendEvents));
       });
+
       test('should emit lifecycle log events', () async {
         await gotoState(module, LifecycleState.loaded);
         expect(
@@ -809,6 +820,12 @@ void runTests(bool runSpanTests) {
           })));
 
           await module.suspend();
+        });
+
+        test('activeSpan should be null when suspend is finished', () async {
+          await gotoState(module, LifecycleState.loaded);
+          await module.suspend();
+          expect(module.activeSpan, isNull);
         });
 
         test(
@@ -1072,6 +1089,12 @@ void runTests(bool runSpanTests) {
           })));
 
           await module.resume();
+        });
+
+        test('activeSpan should be null when resume is finished', () async {
+          await gotoState(module, LifecycleState.suspended);
+          await module.resume();
+          expect(module.activeSpan, isNull);
         });
 
         test(
@@ -2010,6 +2033,11 @@ void runTests(bool runSpanTests) {
           expect(parentUnloadContext?.spanId, isNotNull);
           expect(span.parentContext.spanId, parentUnloadContext.spanId);
           expect(span.tags['custom.unload.tag'], 'somevalue');
+        });
+
+        test('activeSpan should be null when unload is finished', () async {
+          await parentModule.unload();
+          expect(parentModule.activeSpan, isNull);
         });
       }
 


### PR DESCRIPTION
# Description

`_activeSpan` was being retained in memory after modules were unloaded.

# Testing

First, use the wdesk_sdk examples without this branch to reproduce the memory leak issue.

1. Starting from the main examples page, open up an example document and then close it.
2. Watch the network tab. There will be 3 `tracing/` requests. (The period is 30 seconds so if it's been longer than that since the last `tracing/` request it's probably failed)
3. Manually garbage collect and then record a heap with sourcemaps (default behavior for me in Chrome without incognito). Search for `span` (or `Wspan`, etc)

Now point wdesk_sdk to use this branch and try again. After the third `tracing/` request, you shouldn't see any Wspans.

fyi @Workiva/app-frameworks 