### PR TITLE
AF-2971 Dart 2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,5 @@ script:
   - pub run dart_dev format --check
   - pub run dart_dev analyze
   - pub run dart_dev test
-  - pub run dart_dev coverage --no-html
-  - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov
+  - pub run dart_dev dart1-only coverage --no-html && bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
 language: dart
 dart:
   - 1.24.3
+  - stable
+sudo: required
+addons:
+  chrome: stable
+cache:
+  directories:
+    - $HOME/.pub-cache
 script:
-  - pub get --packages-dir
+  - pub get
   - pub run dart_dev format --check
   - pub run dart_dev analyze
   - pub run dart_dev test
   - pub run dart_dev coverage --no-html
   - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ cache:
     - $HOME/.pub-cache
 script:
   - pub get
-  - pub run dart_dev format --check
+  - pub run dart_dev dart2-only -- format --check
   - pub run dart_dev analyze
   - pub run dart_dev test
-  - pub run dart_dev dart1-only coverage --no-html && bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov
+  - pub run dart_dev dart1-only -- coverage --no-html && bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM google/dart:1.24.3 as build
-
-COPY pubspec.* /build/
+WORKDIR /build/
+ADD pubspec.* /build/
 RUN pub get 
 ARG BUILD_ARTIFACTS_BUILD=/build/pubspec.lock
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,6 @@
 FROM google/dart:1.24.3 as build
 
-RUN apt-get update -qq
-RUN apt-get update && apt-get install -y \
-	build-essential \
-	wget \
-	&& rm -rf /var/lib/apt/lists/*
-
-# install chrome
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-	echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list && \
-	apt-get -qq update && apt-get install -y google-chrome-stable && \
-	mv /usr/bin/google-chrome-stable /usr/bin/google-chrome && \
-	sed -i --follow-symlinks -e 's/\"\$HERE\/chrome\"/\"\$HERE\/chrome\" --no-sandbox/g' /usr/bin/google-chrome && \
-	google-chrome --version
-
-
-WORKDIR /build
-
-# setup ssh
-ARG GIT_SSH_KEY
-ARG KNOWN_HOSTS_CONTENT
-RUN mkdir /root/.ssh/ && \
-  echo "$KNOWN_HOSTS_CONTENT" > "/root/.ssh/known_hosts" && \
-  chmod 700 /root/.ssh/ && \
-  umask 0077 && echo "$GIT_SSH_KEY" >/root/.ssh/id_rsa && \
-  eval "$(ssh-agent -s)" && ssh-add /root/.ssh/id_rsa
-
-# grab source
-COPY . /build/
-
-# deps / test / sanity check / build
-ENV DART_FLAGS="--checked"
-ARG BUILD_ID
-ARG GIT_COMMIT
-ARG GIT_TAG
-ARG GIT_BRANCH
-ARG GIT_MERGE_HEAD
-ARG GIT_MERGE_BRANCH
-RUN pub get --packages-dir && \
-	pub run dart_dev test --pub-serve --web-compiler=dartdevc -p chrome -p vm
+COPY pubspec.* /build/
+RUN pub get 
 ARG BUILD_ARTIFACTS_BUILD=/build/pubspec.lock
 FROM scratch

--- a/example/panel/index.html
+++ b/example/panel/index.html
@@ -25,7 +25,7 @@ limitations under the License.
         <div id="panel-container"></div>
 
         <script src="packages/react/react_with_react_dom_prod.js"></script>
-        <script type="application/dart" src="panel_app.dart"></script>
-        <script src="packages/browser/dart.js"></script>
+        <script defer src="panel_app.dart.js"></script>
+        
     </body>
 </html>

--- a/example/panel/modules/data_load_async_module.dart
+++ b/example/panel/modules/data_load_async_module.dart
@@ -110,7 +110,7 @@ class DataLoadAsyncStore extends Store {
 }
 
 // ignore: non_constant_identifier_names
-Object DataLoadAsyncComponent =
+var DataLoadAsyncComponent =
     react.registerComponent(() => new _DataLoadAsyncComponent());
 
 class _DataLoadAsyncComponent

--- a/example/panel/modules/flux_module.dart
+++ b/example/panel/modules/flux_module.dart
@@ -70,7 +70,7 @@ class FluxStore extends Store {
 }
 
 // ignore: non_constant_identifier_names
-Object MyFluxComponent = react.registerComponent(() => new _MyFluxComponent());
+var MyFluxComponent = react.registerComponent(() => new _MyFluxComponent());
 
 class _MyFluxComponent extends FluxComponent<FluxActions, FluxStore> {
   @override

--- a/example/panel/modules/hierarchy_module.dart
+++ b/example/panel/modules/hierarchy_module.dart
@@ -120,7 +120,7 @@ class HierarchyStore extends Store {
 }
 
 // ignore: non_constant_identifier_names
-Object HierarchyComponent =
+var HierarchyComponent =
     react.registerComponent(() => new _HierarchyComponent());
 
 class _HierarchyComponent

--- a/example/panel/modules/panel_module.dart
+++ b/example/panel/modules/panel_module.dart
@@ -85,7 +85,7 @@ class PanelStore extends Store {
   PanelModule _parentModule;
 
   PanelStore(this._actions, this._parentModule) {
-    triggerOnAction(_actions.changeToPanel, _changeToPanel);
+    triggerOnActionV2(_actions.changeToPanel, _changeToPanel);
   }
 
   bool get isRenderable => _isRenderable;
@@ -138,7 +138,7 @@ class PanelStore extends Store {
 }
 
 // ignore: non_constant_identifier_names
-Object PanelComponent = react.registerComponent(() => new _PanelComponent());
+var PanelComponent = react.registerComponent(() => new _PanelComponent());
 
 class _PanelComponent extends FluxComponent<PanelActions, PanelStore> {
   @override

--- a/example/panel/modules/reject_module.dart
+++ b/example/panel/modules/reject_module.dart
@@ -80,7 +80,7 @@ class RejectStore extends Store {
 }
 
 // ignore: non_constant_identifier_names
-Object RejectComponent = react.registerComponent(() => new _RejectComponent());
+var RejectComponent = react.registerComponent(() => new _RejectComponent());
 
 class _RejectComponent extends FluxComponent<RejectActions, RejectStore> {
   @override

--- a/example/panel/modules/sample_tracer.dart
+++ b/example/panel/modules/sample_tracer.dart
@@ -32,8 +32,7 @@ class SampleSpan implements Span {
     this.references,
     DateTime startTime,
     Map<String, dynamic> tags,
-  })
-      : this.startTime = startTime ?? new DateTime.now(),
+  })  : this.startTime = startTime ?? new DateTime.now(),
         this.tags = tags ?? {} {
     if (childOf != null) {
       references.add(new Reference.childOf(childOf));

--- a/example/random_color/index.html
+++ b/example/random_color/index.html
@@ -37,7 +37,7 @@ limitations under the License.
         </div>
 
         <script src="packages/react/react_with_react_dom_prod.js"></script>
-        <script type="application/dart" src="random_color.dart"></script>
-        <script src="packages/browser/dart.js"></script>
+        <script defer src="random_color.dart.js"></script>
+        
     </body>
 </html>

--- a/example/random_color/random_color.dart
+++ b/example/random_color/random_color.dart
@@ -159,7 +159,7 @@ class RandomColorStore extends Store {
 }
 
 // ignore: non_constant_identifier_names
-Object RandomColorComponent =
+var RandomColorComponent =
     react.registerComponent(() => new _RandomColorComponent());
 
 class _RandomColorComponent

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -594,7 +594,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
           ]);
     }
 
-    Future pendingTransition;
+    Future<Null> pendingTransition;
     if (_transition != null && !_transition.isCompleted) {
       pendingTransition = _transition.future.then((_) {
         _activeSpan = _startTransitionSpan('suspend');
@@ -661,7 +661,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
           allowedStates: [LifecycleState.suspended, LifecycleState.suspending]);
     }
 
-    Future pendingTransition;
+    Future<Null> pendingTransition;
     if (_transition != null && !_transition.isCompleted) {
       pendingTransition = _transition.future.then((_) {
         _activeSpan = _startTransitionSpan('resume');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
   dart_dev: ^2.0.0
   dart_style: ^1.0.9
   mockito: ">=2.2.2 <4.0.0"
-  react: ^4.5.0
+  react: ^4.4.2
   test: ">=0.12.30 <2.0.0"
   w_flux: ">=1.0.0 <3.0.0"
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ authors:
 homepage: https://github.com/Workiva/w_module
 
 environment:
-  sdk: '>=1.24.3<3.0.0'
+  sdk: '>=1.24.3 <3.0.0'
 
 dependencies:
   logging: ^0.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,9 @@ authors:
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/w_module
 
+environment:
+  sdk: '>=1.24.3<3.0.0'
+
 dependencies:
   logging: ^0.11.0
   meta: ^1.0.0
@@ -18,18 +21,19 @@ dependencies:
   w_common: ^1.9.0
 
 dev_dependencies:
-  browser: ^0.10.0+2
-  coverage: ^0.7.3
-  dart_dev: ^1.8.0
-  dart_style: ^1.0.7
-  dartdoc: ">=0.13.0 <0.16.0"
-  mockito: ^1.0.1
-  react: ^3.0.0
-  test: ^0.12.0
-  w_flux: '>=1.0.0 <3.0.0'
-
-environment:
-  sdk: '>=1.9.0 <2.0.0'
+  build_runner: ">=0.6.0 <1.0.0"
+  build_test: ">=0.9.0 <1.0.0"
+  build_web_compilers: ">=0.2.0 <1.0.0"
+  coverage: ">=0.10.0 <0.13.0"
+  dart_dev: ^2.0.0
+  dart_style: ^1.0.9
+  mockito: ">=2.2.2 <4.0.0"
+  react: ^4.5.0
+  test: ">=0.12.30 <2.0.0"
+  w_flux: #">=1.0.0 <3.0.0"
+    git:
+      url: git@github.com:Workiva/w_flux.git
+      ref: dart2_really
 
 transformers:
   - test/pub_serve:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,10 +30,7 @@ dev_dependencies:
   mockito: ">=2.2.2 <4.0.0"
   react: ^4.5.0
   test: ">=0.12.30 <2.0.0"
-  w_flux: #">=1.0.0 <3.0.0"
-    git:
-      url: git@github.com:Workiva/w_flux.git
-      ref: dart2_really
+  w_flux: ">=1.0.0 <3.0.0"
 
 transformers:
   - test/pub_serve:

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -159,7 +159,6 @@ class TestLifecycleModule extends LifecycleModule {
   @override
   @protected
   Future<Null> onDidUnloadChildModule(LifecycleModule module) async {
-    await new Future.value(null);
     if (onDidUnloadChildModuleError != null) {
       throw onDidUnloadChildModuleError;
     }

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -149,6 +149,7 @@ class TestLifecycleModule extends LifecycleModule {
   @override
   @protected
   Future<Null> onWillUnloadChildModule(LifecycleModule module) async {
+    await new Future.value(null);
     if (onWillUnloadChildModuleError != null) {
       throw onWillUnloadChildModuleError;
     }
@@ -158,6 +159,7 @@ class TestLifecycleModule extends LifecycleModule {
   @override
   @protected
   Future<Null> onDidUnloadChildModule(LifecycleModule module) async {
+    await new Future.value(null);
     if (onDidUnloadChildModuleError != null) {
       throw onDidUnloadChildModuleError;
     }
@@ -280,6 +282,8 @@ void expectInLifecycleState(LifecycleModule module, LifecycleState state) {
 }
 
 Future<Null> gotoState(LifecycleModule module, LifecycleState state) async {
+  // wait for next event loop. fixes sync-async in Dart 2
+  await new Future.value(null);
   if (state == LifecycleState.instantiated) {
     return;
   }
@@ -288,7 +292,7 @@ Future<Null> gotoState(LifecycleModule module, LifecycleState state) async {
   if (state == LifecycleState.loading) {
     return;
   }
-  await future;
+  await future; // Dart 2 would have run synchronously up until this await
   if (state == LifecycleState.loaded) {
     return;
   }

--- a/test/test_tracer.dart
+++ b/test/test_tracer.dart
@@ -32,8 +32,7 @@ class TestSpan implements Span {
     List<Reference> references,
     DateTime startTime,
     Map<String, dynamic> tags,
-  })
-      : this.startTime = startTime ?? new DateTime.now(),
+  })  : this.startTime = startTime ?? new DateTime.now(),
         this.tags = tags ?? {},
         this.references = references ?? [] {
     if (childOf != null) {


### PR DESCRIPTION
# Overview
Updates are needed to use this library under Dart 2

# Changes
 - updated analysis options and renamed to the proper name
 - updated dependencies and dart sdk ranges in pubspec.yaml
 - unit tests fixed for dart 2.
 - fixed some type errors in the examples
 - CI now enforces dartfmt under dart 2

# Testing
 - [ ] CI passes under dart 1 and dart 2