### PR TITLE
Clear child modules on dispose.

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -514,6 +514,14 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
           onError: (error, stackTrace) =>
               _didUnloadChildModuleController.addError);
 
+      // The child module may not reach an unloaded state successfully, but
+      // should always eventually be disposed. For this reason, we listen for
+      // its disposal before removing it from the list of child modules.
+      // ignore: unawaited_futures
+      childModule.didDispose.then((_) {
+        _childModules.remove(childModule);
+      });
+
       try {
         manageDisposable(childModule);
         _childModules.add(childModule);

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -483,7 +483,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   /// Attempting to load a child module after a module has been unloaded will
   /// throw a [StateError].
   @protected
-  Future<Null> loadChildModule(LifecycleModule childModule) {//
+  Future<Null> loadChildModule(LifecycleModule childModule) {
     if (isOrWillBeDisposed) {
       return _buildDisposedOrDisposingResponse(methodName: 'loadChildModule');
     }

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -483,7 +483,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   /// Attempting to load a child module after a module has been unloaded will
   /// throw a [StateError].
   @protected
-  Future<Null> loadChildModule(LifecycleModule childModule) {
+  Future<Null> loadChildModule(LifecycleModule childModule) {//
     if (isOrWillBeDisposed) {
       return _buildDisposedOrDisposingResponse(methodName: 'loadChildModule');
     }
@@ -887,6 +887,17 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
     if (_childModules.isNotEmpty) {
       await Future.wait(_childModules.map((child) => child.dispose()));
     }
+  }
+
+  @mustCallSuper
+  @override
+  @protected
+  Future<Null> onDispose() async {
+    if (isInstantiated || isUnloaded) {
+      return;
+    }
+
+    _childModules.clear();
   }
 
   Future<Null> _buildDisposedOrDisposingResponse(

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -1500,6 +1500,12 @@ void runTests(bool runSpanTests) {
                 }
               });
 
+              tearDown(() {
+                if (withChild) {
+                  expect(module.childModules, isEmpty);
+                }
+              });
+
               test('should unload and then dispose', () async {
                 expectInLifecycleState(module, state);
                 await module.dispose();


### PR DESCRIPTION
## Problem
We're seeing modules get leaking text_doc_client.

## Solution
We think that clearing the list of modules is a fail-safe solution to ensure that we don't retain references to children modules when we've been disposed.

@jacobjohnson-wf @evanweible-wf @bencampbell-wf 