### PR TITLE
AF-3155 Release w_module 2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+## [2.0.5](https://github.com/Workiva/w_module/compare/2.0.4...2.0.5)
+
+_December 13, 2018_
+
+- **Bug Fix:** Address some memory leak edge cases around child modules:
+  - Clear the list of child modules when the parent module is disposed.
+  - Use `manageDisposable()` to manage a child module as soon as it is added
+    instead of manually disposing each child module during parent module
+    disposal.
+
+## [2.0.4](https://github.com/Workiva/w_module/compare/2.0.3...2.0.4)
+
+_November 27, 2018_
+
+- **Improvement:** Dart 2 compatible!
+
+## [2.0.3](https://github.com/Workiva/w_module/compare/2.0.0...2.0.3)
+
+_October 16, 2018_
+
+- **Feature:** Added OpenTracing support to `Module`.
+
+  See [the tracing documentation][tracing] for more info.
+
+## [2.0.0](https://github.com/Workiva/w_module/compare/1.6.2...2.0.0)
+
+_Sep 13, 2018_
+
+[tracing]: https://github.com/Workiva/w_module/blob/master/documentation/tracing.md
+
+- **BREAKING CHANGE:** Remove the `package:w_module/serializable_module.dart`
+  entry point, as it depended on `dart:mirrors` which is no longer supported in
+  the browser in Dart 2.
+
+  Consequently, the following API members have been removed:
+
+  - `Bridge`
+  - `Reflectable`
+  - `SerializableBus`
+  - `SerializableEvent`
+  - `SerializableEvents`
+  - `SerializableModule`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_module
-version: 2.0.4
+version: 2.0.5
 description: Base module classes with a well defined lifecycle for modular Dart applications.
 authors:
   - Workiva Client Platform Team <team-clientplatform@workiva.com>


### PR DESCRIPTION

Pull Requests included in release:
* [Clear child modules on dispose.](https://github.com/Workiva/w_module/pull/139)


Requested by: @greg.littlefield

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_module/compare/2.0.4...Workiva:release_w_module_2.0.5
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_module/compare/2.0.4...2.0.5

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5416683323785216/logs/)