### PR TITLE
Increase opentracing version for basictracer-dart changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: dart
 dart:
-  - 1.24.3
   - stable
 sudo: required
 addons:
@@ -13,5 +12,3 @@ script:
   - pub run dart_dev dart2-only -- format --check
   - pub run dart_dev analyze
   - pub run dart_dev test
-  - pub run dart_dev dart1-only -- coverage --no-html && bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,39 @@
-FROM google/dart:1.24.3 as build
+FROM google/dart:2.2 as dart2
+FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:355624 as build
+
+# Build Environment Vars
+ARG BUILD_ID
+ARG BUILD_NUMBER
+ARG BUILD_URL
+ARG GIT_COMMIT
+ARG GIT_BRANCH
+ARG GIT_TAG
+ARG GIT_COMMIT_RANGE
+ARG GIT_HEAD_URL
+ARG GIT_MERGE_HEAD
+ARG GIT_MERGE_BRANCH
+ARG GIT_SSH_KEY
+ARG KNOWN_HOSTS_CONTENT
+
+RUN mkdir /root/.ssh
+RUN echo "$KNOWN_HOSTS_CONTENT" > "/root/.ssh/known_hosts"
+RUN echo "$GIT_SSH_KEY" > "/root/.ssh/id_rsa"
+RUN chmod 700 /root/.ssh/
+RUN chmod 600 /root/.ssh/id_rsa
+
 WORKDIR /build/
-ADD pubspec.* /build/
-RUN pub get 
-ARG BUILD_ARTIFACTS_BUILD=/build/pubspec.lock
+ADD . /build/
+ENV CODECOV_TOKEN='bQ4MgjJ0G2Y73v8JNX6L7yMK9679nbYB'
+RUN echo "Starting the script sections"
+RUN eval "$(ssh-agent -s)" && ssh-add /root/.ssh/id_rsa
+# Use pub from Dart 2 to initially resolve dependencies since it is much more efficient.
+COPY --from=dart2 /usr/lib/dart /usr/lib/dart2
+RUN echo "Running Dart 2 pub get.." && \
+	_PUB_TEST_SDK_VERSION=1.24.3 timeout 5m /usr/lib/dart2/bin/pub get --no-precompile
+RUN pub get
+RUN pub run dart_dev dart1-only -- coverage --no-html
+RUN curl https://codecov.workiva.net/bash > ./codecov.sh
+RUN chmod a+x ./codecov.sh
+RUN ./codecov.sh -u https://codecov.workiva.net -t $CODECOV_TOKEN -r Workiva/w_module -f coverage/coverage.lcov
+
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,16 @@ FROM google/dart:2.2 as dart2
 FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:355624 as build
 
 # Build Environment Vars
+ARG GIT_SSH_KEY
+ARG KNOWN_HOSTS_CONTENT
+
+RUN mkdir /root/.ssh
+RUN echo "$KNOWN_HOSTS_CONTENT" > "/root/.ssh/known_hosts"
+RUN echo "$GIT_SSH_KEY" > "/root/.ssh/id_rsa"
+RUN chmod 700 /root/.ssh/
+RUN chmod 600 /root/.ssh/id_rsa
+
+# Build Environment Vars
 ARG BUILD_ID
 ARG BUILD_NUMBER
 ARG BUILD_URL
@@ -12,14 +22,7 @@ ARG GIT_COMMIT_RANGE
 ARG GIT_HEAD_URL
 ARG GIT_MERGE_HEAD
 ARG GIT_MERGE_BRANCH
-ARG GIT_SSH_KEY
-ARG KNOWN_HOSTS_CONTENT
 
-RUN mkdir /root/.ssh
-RUN echo "$KNOWN_HOSTS_CONTENT" > "/root/.ssh/known_hosts"
-RUN echo "$GIT_SSH_KEY" > "/root/.ssh/id_rsa"
-RUN chmod 700 /root/.ssh/
-RUN chmod 600 /root/.ssh/id_rsa
 
 WORKDIR /build/
 ADD . /build/

--- a/example/panel/modules/sample_tracer.dart
+++ b/example/panel/modules/sample_tracer.dart
@@ -33,8 +33,7 @@ class SampleSpan implements Span {
     this.references,
     DateTime startTime,
     Map<String, dynamic> tags,
-  })
-      : this.startTime = startTime ?? new DateTime.now(),
+  })  : this.startTime = startTime ?? new DateTime.now(),
         this.tags = tags ?? {} {
     if (childOf != null) {
       references.add(new Reference.childOf(childOf));

--- a/example/panel/modules/sample_tracer.dart
+++ b/example/panel/modules/sample_tracer.dart
@@ -22,6 +22,7 @@ class SampleSpan implements Span {
 
   @override
   final DateTime startTime;
+
   DateTime _endTime;
 
   Completer<Span> _whenFinished = new Completer<Span>();
@@ -32,7 +33,8 @@ class SampleSpan implements Span {
     this.references,
     DateTime startTime,
     Map<String, dynamic> tags,
-  })  : this.startTime = startTime ?? new DateTime.now(),
+  })
+      : this.startTime = startTime ?? new DateTime.now(),
         this.tags = tags ?? {} {
     if (childOf != null) {
       references.add(new Reference.childOf(childOf));
@@ -78,6 +80,9 @@ class SampleSpan implements Span {
 
   @override
   void setTag(String tagName, dynamic value) => tags[tagName] = value;
+
+  @override
+  set startTime(DateTime value) => startTime = value;
 
   @override
   Future<Span> get whenFinished => _whenFinished.future;
@@ -157,4 +162,10 @@ class SampleTracer implements AbstractTracer {
   Future<dynamic> flush() {
     return null;
   }
+
+  @override
+  ScopeManager scopeManager;
+
+  @override
+  Span get activeSpan => scopeManager?.active?.span;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 dependencies:
   logging: ^0.11.0
   meta: ^1.0.0
-  opentracing: ^0.2.3
+  opentracing: ^1.0.1
   platform_detect: ^1.1.0
   w_common: ^1.9.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 dependencies:
   logging: ^0.11.0
   meta: ^1.0.0
-  opentracing: ^1.0.1
+  opentracing: ">=0.2.3 <2.0.0"
   platform_detect: ^1.1.0
   w_common: ^1.9.0
 

--- a/test/test_tracer.dart
+++ b/test/test_tracer.dart
@@ -32,8 +32,7 @@ class TestSpan implements Span {
     List<Reference> references,
     DateTime startTime,
     Map<String, dynamic> tags,
-  })
-      : this.startTime = startTime ?? new DateTime.now(),
+  })  : this.startTime = startTime ?? new DateTime.now(),
         this.tags = tags ?? {},
         this.references = references ?? [] {
     if (childOf != null) {

--- a/test/test_tracer.dart
+++ b/test/test_tracer.dart
@@ -32,7 +32,8 @@ class TestSpan implements Span {
     List<Reference> references,
     DateTime startTime,
     Map<String, dynamic> tags,
-  })  : this.startTime = startTime ?? new DateTime.now(),
+  })
+      : this.startTime = startTime ?? new DateTime.now(),
         this.tags = tags ?? {},
         this.references = references ?? [] {
     if (childOf != null) {
@@ -79,6 +80,9 @@ class TestSpan implements Span {
 
   @override
   void setTag(String tagName, dynamic value) => tags[tagName] = value;
+
+  @override
+  set startTime(DateTime value) => startTime = value;
 
   @override
   Future<Span> get whenFinished => _whenFinished.future;
@@ -162,4 +166,10 @@ class TestTracer implements AbstractTracer {
   Future<dynamic> flush() {
     return null;
   }
+
+  @override
+  ScopeManager scopeManager;
+
+  @override
+  Span get activeSpan => scopeManager?.active?.span;
 }


### PR DESCRIPTION
With version `1.1.0` of basictracer-dart, the opentracing version was increased to `1.0.0`. To prevent dependency conflicts, increase w_module's version to accommodate the changes.

@Workiva/app-frameworks 