### PR TITLE
CPLAT-5450: Updates to better support the first render use case

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -72,36 +72,36 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
 
   // Lifecycle event StreamControllers
   StreamController<LifecycleModule> _willLoadChildModuleController =
-  new StreamController<LifecycleModule>.broadcast();
+      new StreamController<LifecycleModule>.broadcast();
   StreamController<LifecycleModule> _didLoadChildModuleController =
-  new StreamController<LifecycleModule>.broadcast();
+      new StreamController<LifecycleModule>.broadcast();
 
   StreamController<LifecycleModule> _willLoadController =
-  new StreamController<LifecycleModule>.broadcast();
+      new StreamController<LifecycleModule>.broadcast();
   StreamController<LifecycleModule> _didLoadController =
-  new StreamController<LifecycleModule>.broadcast();
+      new StreamController<LifecycleModule>.broadcast();
   StreamController<LifecycleModule> _isFirstUsefulController =
-  new StreamController<LifecycleModule>.broadcast();
+      new StreamController<LifecycleModule>.broadcast();
 
   StreamController<LifecycleModule> _willSuspendController =
-  new StreamController<LifecycleModule>.broadcast();
+      new StreamController<LifecycleModule>.broadcast();
   StreamController<LifecycleModule> _didSuspendController =
-  new StreamController<LifecycleModule>.broadcast();
+      new StreamController<LifecycleModule>.broadcast();
 
   StreamController<LifecycleModule> _willResumeController =
-  new StreamController<LifecycleModule>.broadcast();
+      new StreamController<LifecycleModule>.broadcast();
   StreamController<LifecycleModule> _didResumeController =
-  new StreamController<LifecycleModule>.broadcast();
+      new StreamController<LifecycleModule>.broadcast();
 
   StreamController<LifecycleModule> _willUnloadChildModuleController =
-  new StreamController<LifecycleModule>.broadcast();
+      new StreamController<LifecycleModule>.broadcast();
   StreamController<LifecycleModule> _didUnloadChildModuleController =
-  new StreamController<LifecycleModule>.broadcast();
+      new StreamController<LifecycleModule>.broadcast();
 
   StreamController<LifecycleModule> _willUnloadController =
-  new StreamController<LifecycleModule>.broadcast();
+      new StreamController<LifecycleModule>.broadcast();
   StreamController<LifecycleModule> _didUnloadController =
-  new StreamController<LifecycleModule>.broadcast();
+      new StreamController<LifecycleModule>.broadcast();
 
   // constructor necessary to init load / unload state stream
   LifecycleModule() {
@@ -214,16 +214,11 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
     List<Reference> references: const [],
     DateTime trueStartTime,
   }) {
-    specifyStartupTiming(
-      StartupTimingType.firstUseful,
-      tags: tags,
-      references: references,
-      trueStartTime: trueStartTime
-    );
+    specifyStartupTiming(StartupTimingType.firstUseful,
+        tags: tags, references: references, trueStartTime: trueStartTime);
 
     _isFirstUsefulController.add(this);
   }
-
 
   /// Creates a span with `globalTracer` from the start of [load] until now.
   ///
@@ -232,11 +227,11 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   /// Any [tags] or [references] specified will be added to this span.
   @protected
   void specifyStartupTiming(
-      StartupTimingType specifier, {
-        Map<String, dynamic> tags: const {},
-        List<Reference> references: const [],
-        DateTime trueStartTime,
-      }) {
+    StartupTimingType specifier, {
+    Map<String, dynamic> tags: const {},
+    List<Reference> references: const [],
+    DateTime trueStartTime,
+  }) {
     // Start time for load was overridden in the case of deferred module rendering
     DateTime startTime = trueStartTime ?? _startLoadTime;
 
@@ -251,15 +246,16 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       return null;
     }
 
-    _logger.finest('specifyStartupTiming for $name. It took ${new DateTime.now().difference(startTime).inSeconds} seconds for this module to be interactable.');
+    _logger.finest(
+        'specifyStartupTiming for $name. It took ${new DateTime.now().difference(startTime).inSeconds} seconds for this module to be interactable.');
 
-      tracer
+    tracer
         .startSpan(
-      '$name.${specifier.operationName}',
-      references: [tracer.followsFrom(_loadContext)]..addAll(references),
-      startTime: startTime,
-      tags: _defaultTags..addAll(tags),
-    )
+          '$name.${specifier.operationName}',
+          references: [tracer.followsFrom(_loadContext)]..addAll(references),
+          startTime: startTime,
+          tags: _defaultTags..addAll(tags),
+        )
         .finish();
 
     _startLoadTime = null;
@@ -270,9 +266,9 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   String get name => _defaultName;
 
   Map<String, dynamic> get _defaultTags => {
-    'span.kind': 'client',
-    'module.instance_id': _instanceId,
-  };
+        'span.kind': 'client',
+        'module.instance_id': _instanceId,
+      };
 
   /// Deprecated: the module name should be defined by overriding the getter in
   /// a subclass and it should not be mutable.
@@ -461,7 +457,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
           isTransitioning: isLoading,
           methodName: 'load',
           currentState:
-          isLoading ? LifecycleState.loading : LifecycleState.loaded);
+              isLoading ? LifecycleState.loading : LifecycleState.loaded);
     }
 
     if (!isInstantiated) {
@@ -537,7 +533,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       final childModuleDidUnloadSub = listenToStream(
           childModule.didUnload, _onChildModuleDidUnload,
           onError: (error, stackTrace) =>
-          _didUnloadChildModuleController.addError);
+              _didUnloadChildModuleController.addError);
 
       // The child module may not reach an unloaded state successfully, but
       // should always eventually be disposed. For this reason, we listen for
@@ -682,7 +678,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
           isTransitioning: isResuming,
           methodName: 'resume',
           currentState:
-          isResuming ? LifecycleState.resuming : LifecycleState.loaded);
+              isResuming ? LifecycleState.resuming : LifecycleState.loaded);
     }
 
     if (!(isSuspended || isSuspending)) {
@@ -778,7 +774,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
           isTransitioning: isUnloading,
           methodName: 'unload',
           currentState:
-          isUnloading ? LifecycleState.unloading : LifecycleState.unloaded);
+              isUnloading ? LifecycleState.unloading : LifecycleState.unloaded);
     }
 
     if (isOrWillBeDisposed) {
@@ -909,7 +905,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       // here explaining that disposal will still continue.
       _logger.warning(
           '.dispose() was called but Module "$name" threw an exception on '
-              'unload. The module will still be disposed.',
+          'unload. The module will still be disposed.',
           error,
           stackTrace);
     }
@@ -918,7 +914,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   Future<Null> _buildDisposedOrDisposingResponse(
       {@required String methodName}) {
     _logger.warning('.$methodName() was called after Module "$name" had '
-    // ignore: deprecated_member_use
+        // ignore: deprecated_member_use
         'already ${isDisposing ? 'started disposing' : 'disposed'}.');
     return new Future.error(new StateError(
         'Calling .$methodName() after disposal has started is not allowed.'));
@@ -927,20 +923,20 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   /// Returns a new [Future] error with a constructed reason.
   Future<Null> _buildIllegalTransitionResponse(
       {LifecycleState targetState,
-        Iterable<LifecycleState> allowedStates,
-        String reason}) {
+      Iterable<LifecycleState> allowedStates,
+      String reason}) {
     reason = reason ??
         'Only a module in the '
-            '${allowedStates.map(_readableStateName).join(", ")} states can '
-            'transition to ${_readableStateName(targetState)}';
+        '${allowedStates.map(_readableStateName).join(", ")} states can '
+        'transition to ${_readableStateName(targetState)}';
     return new Future.error(new StateError(
         'Transitioning from $_state to $targetState is not allowed. $reason'));
   }
 
   Future<Null> _buildNoopResponse(
       {@required String methodName,
-        @required LifecycleState currentState,
-        @required isTransitioning}) {
+      @required LifecycleState currentState,
+      @required isTransitioning}) {
     _logger.warning('.$methodName() was called while Module "$name" is already '
         '${_readableStateName(currentState)}; this is a no-op. Check for any '
         'unnecessary calls to .$methodName().');

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -112,24 +112,25 @@ class TestLifecycleModule extends LifecycleModule {
       super.loadChildModule(newModule);
 
   @override
-  void specifyFirstUsefulState({
-    // ignore: invalid_override_different_default_values_named
-    Map<String, dynamic> tags: const {},
-    // ignore: invalid_override_different_default_values_named
-    List<Reference> references: const [],
-  }) =>
+  void specifyFirstUsefulState(
+          {
+          // ignore: invalid_override_different_default_values_named
+          Map<String, dynamic> tags: const {},
+          // ignore: invalid_override_different_default_values_named
+          List<Reference> references: const [],
+          DateTime trueStartTime}) =>
       super.specifyFirstUsefulState(tags: tags, references: references);
 
   // Overriding without re-applying the @protected annotation allows us to call
   // specifyStartupTiming in our tests below.
   @override
-  void specifyStartupTiming(
-    StartupTimingType specifier, {
-    // ignore: invalid_override_different_default_values_named
-    Map<String, dynamic> tags: const {},
-    // ignore: invalid_override_different_default_values_named
-    List<Reference> references: const [],
-  }) =>
+  void specifyStartupTiming(StartupTimingType specifier,
+          {
+          // ignore: invalid_override_different_default_values_named
+          Map<String, dynamic> tags: const {},
+          // ignore: invalid_override_different_default_values_named
+          List<Reference> references: const [],
+          DateTime trueStartTime}) =>
       super.specifyStartupTiming(specifier, tags: tags, references: references);
 
   @override


### PR DESCRIPTION
## Motivation
First useful should be a publicly subscript-able event that parents can listen for.

#### Release Notes
Parent containers can now listen to child modules for their first useful events in better tracking component initial renders. ?? idk

## Review
Please review: @greglittlefield-wf @evanweible-wf 

### QA Checklist
- [] Tests were updated and provide good coverage of the changeset and other affected code
**Do you want me to do anything here?**
- [ ] Manual testing was performed if needed

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#manual-testing-criteria
