### PR TITLE
CPLAT-5491 Injectable logger implementation [WIP]

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -953,7 +953,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
         await onLoad();
       } catch (error, stackTrace) {
         logger.severe(
-          'Exception during onLoad ($name)',
+          'Exception in onLoad ($name)',
           error,
           stackTrace,
         );
@@ -983,12 +983,11 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       _didUnloadChildModuleController.add(module);
     } catch (error, stackTrace) {
       logger.severe(
-        'Exception during onDidUnloadChildModule ($name)',
+        'Exception in onDidUnloadChildModule ($name)',
         error,
         stackTrace,
       );
       _didUnloadChildModuleController.addError(error, stackTrace);
-      return;
     }
   }
 
@@ -999,12 +998,11 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       _willUnloadChildModuleController.add(module);
     } catch (error, stackTrace) {
       logger.severe(
-        'Exception during onWillUnloadChildModule ($name)',
+        'Exception in onWillUnloadChildModule ($name)',
         error,
         stackTrace,
       );
       _willUnloadChildModuleController.addError(error, stackTrace);
-      return;
     }
   }
 
@@ -1031,7 +1029,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
         await onResume();
       } catch (error, stackTrace) {
         logger.severe(
-          'Exception during onResume ($name)',
+          'Exception in onResume ($name)',
           error,
           stackTrace,
         );
@@ -1067,7 +1065,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
         await onSuspend();
       } catch (error, stackTrace) {
         logger.severe(
-          'Exception during onSuspend ($name)',
+          'Exception in onSuspend ($name)',
           error,
           stackTrace,
         );
@@ -1094,6 +1092,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
         _state = _previousState;
         _previousState = null;
         _transition = null;
+        // TODO: We throw, but we can't do anything useful with the exception
         // reject with shouldUnload messages
         throw new ModuleUnloadCanceledException(
             shouldUnloadResult.messagesAsString());
@@ -1113,7 +1112,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
         await onUnload();
       } catch (error, stackTrace) {
         logger.severe(
-          'Exception during onUnload ($name)',
+          'Exception in onUnload ($name)',
           error,
           stackTrace,
         );
@@ -1128,6 +1127,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
     } on ModuleUnloadCanceledException catch (error, _) {
       // In the event of a cancellation, rethrow the exception and allow the
       // caller (either unload() or onWillDispose()) to handle it.
+      // TODO: So we just rethrow it, which means it escapes the module
       rethrow;
     } catch (error, stackTrace) {
       // In the event of a failed unload (the module threw an exception but did
@@ -1136,6 +1136,8 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       // onWillDispose()) can handle it.
       _didUnloadController.addError(error, stackTrace);
       _activeSpan?.setTag('error', true);
+      // TODO: Should we just log severe here and not rethrow?
+      // TODO: We could do similarly with the other methods
       rethrow;
     } finally {
       _activeSpan?.finish();

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -16,6 +16,7 @@ library w_module.src.lifecycle_module;
 
 import 'dart:async';
 
+import 'dart:math';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart' show mustCallSuper, protected, required;
 import 'package:opentracing/opentracing.dart';
@@ -315,6 +316,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   /// Any error or exception thrown during the child [LifecycleModule]'s
   /// [unload] call will be emitted.
   ///
+  /// TODO: Update these docs based on the refactor
   /// Any error or exception thrown during the [LifecycleModule]'s
   /// [onUnload] call will be emitted.
   Stream<LifecycleModule> get didUnload => _didUnloadController.stream;
@@ -408,6 +410,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   /// In short, calling [dispose] forces the disposal of this module regardless
   /// of its current state and regardless of its ability to unload successfully.
   ///
+  /// // TODO: This paragraph may need updating
   /// If the modules unload is canceled or if an error is thrown during a
   /// lifecycle handler like onUnload as a part of this disposal process, they
   /// will still be available via their corresponding lifecycle event streams
@@ -430,6 +433,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   /// and the method is a noop. If the module is in any other state, a
   /// StateError is thrown.
   ///
+  /// TODO: Need to change this
   /// If an [Exception] is thrown during the call to [onLoad] it will be emitted
   /// on the [didLoad] lifecycle stream. The returned [Future] will also resolve
   /// with this exception.
@@ -542,7 +546,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
           await onDidLoadChildModule(childModule);
         } catch (error, stackTrace) {
           logger.severe(
-            'Exception during onDidLoadChildModule ($name)',
+            'Exception in onDidLoadChildModule ($name)',
             error,
             stackTrace,
           );
@@ -564,7 +568,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       }
     }).catchError((Object error, StackTrace stackTrace) {
       logger.severe(
-        'Exception during onWillLoadChildModule ($name)',
+        'Exception in onWillLoadChildModule ($name)',
         error,
         stackTrace,
       );
@@ -1063,6 +1067,9 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       await Future.wait(childSuspendFutures);
       try {
         await onSuspend();
+        if (new Random().nextDouble() < 0.05) {
+          throw new Exception('FOOBAR');
+        }
       } catch (error, stackTrace) {
         logger.severe(
           'Exception in onSuspend ($name)',


### PR DESCRIPTION
## Motivation

We would like to make it easier for consumers to find out about exceptions that occur in their module code, versus the underlying module implementation code.

## Changes

To do this, we will allow them to provide us with a logger that we will use in certain situations, such as if any of the lifecycle callbacks throw an exception.

Further, in cases where exceptions are actually in implementor code, we will no longer re-throw.

| Place we might throw | Whose logger we use | Do we throw? |
| --- | --- | --- |
| loadChildModule() | w_module | yes |
| load() | w_module | yes |
| suspend() | w_module | yes |
| resume() | w_module | yes |
| unload() | w_module | yes |
| onLoad() | implementer | no |
| onSuspend() | implementer | no |
| onResume() | implementer | no |
| onUnload() | implementer | no |
| onDidLoadChildModule() | implementer | no |
| onDidUnloadChildModule() | implementer | no |
| onWillLoadChildModule() | implementer | no |
| onWillUnloadChildModule() | implementer | no |
| already disposed | w_module | yes |
| illegal state transition | w_module | yes |
| negative shouldUnload | ??? | ??? |

I'd like to discuss what we expect from `shouldUnload`. Do we use it? Do we need it? It creates kind of a hole in our error handling because the method itself doesn't throw, but we can throw in the `unload` method depending on the result of `shouldUnload`.

#### Release Notes

Lifecyle methods that result in an exception caused by one of the lifecycle callbacks, such as `onLoad`, will no longer result in an exception for the caller. Instead, they will be logged (severe) using the logger returned by the protected `logger` getter. This allows implementers to provide their own logger so that they can be alerted when their code throws, versus when lower-level module code throws.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#manual-testing-criteria

@evanweible-wf @todbachman-wf 