### PR TITLE
Point out listenToStream usage with events in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,17 @@ sampleModule.events.valueChanged.listen((newValue) {
 });
 ```
 
+In order to automatically clean up subscriptions if the module is disposed, you can make use of `listenToStream` instead of the buit-in `listen`. See [the section on disposal](#disposal) for more details.
+
+
+```dart
+
+// module events consumption
+listenToStream(sampleModule.events.valueChanged, (newValue) {
+  ...
+});
+```
+
 If using `w_module` with `w_flux` internals, `events` should usually be dispatched by internal stores immediately
 prior to a corresponding trigger dispatch.  `events` should NOT be dispatched directly by UI components or in
 immediate response to actions.  This ensures that the internal unidirectional data flow is maintained and external

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ sampleModule.events.valueChanged.listen((newValue) {
 });
 ```
 
-In order to automatically clean up subscriptions if the module is disposed, you can make use of `listenToStream` instead of the buit-in `listen`. See [the section on disposal](#disposal) for more details.
+In order to automatically clean up subscriptions if the module is disposed, you can make use of `listenToStream` instead of the built-in `listen`. See [the section on disposal](#disposal) for more details.
 
 
 ```dart


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
In general we prefer `listenToStream` as opposed to `listen` with events, so I added a section of the README that describes how to do this.

## Changes
  <!-- What this PR changes to fix the problem. -->
Simple README update with example.
