### PR TITLE
CPLAT-6674: Add missing module name override(s)

### DIFF
--- a/example/panel/modules/lifecycle_echo_module.dart
+++ b/example/panel/modules/lifecycle_echo_module.dart
@@ -91,4 +91,7 @@ class LifecycleEchoComponents implements ModuleComponents {
       ]);
 }
 
-class LifecycleEchoChildModule extends Module {}
+class LifecycleEchoChildModule extends Module {
+  @override
+  final String name = 'LifecycleEchoChildModule';
+}

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -46,6 +46,9 @@ class UnnamedModule extends LifecycleModule {
 }
 
 class TestLifecycleModule extends LifecycleModule {
+  @override
+  final String name = 'TestLifecycleModule';
+
   Iterable<StreamSubscription<LifecycleModule>> _eventListStreamSubscriptions;
 
   Duration onLoadDelay;

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -32,6 +32,9 @@ const String shouldUnloadError = 'Mock shouldUnload false message';
 class MockStreamSubscription extends Mock implements StreamSubscription<Null> {}
 
 class UnnamedModule extends LifecycleModule {
+  @override
+  final String name = 'UnnamedModule';
+
   // This module does not override the name getter
   // so lifecycle methods should not create spans
 
@@ -58,7 +61,7 @@ class TestLifecycleModule extends LifecycleModule {
   Error onWillUnloadChildModuleError;
 
   @override
-  final String name;
+  final String name = 'TestLifecycleModule';
 
   // mock data to be used for test validation
   List<String> eventList;

--- a/test/module_test.dart
+++ b/test/module_test.dart
@@ -16,7 +16,10 @@
 import 'package:test/test.dart';
 import 'package:w_module/w_module.dart';
 
-class TestModule extends Module {}
+class TestModule extends Module {
+  @override
+  final String name = 'TestModule';
+}
 
 void main() {
   group('Module', () {


### PR DESCRIPTION
We’ve got a pretty large number of severe logs coming 
    through with a null module name.This represents about 90% 
    of the severe logs. Would be nice if we could get module 
    names added to the rest of our code