### PR TITLE
CPLAT-6851: Add disposable type name(s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 build
 packages
 pubspec.lock
+.dart_tool/
 
 # docs
 /doc/api/

--- a/lib/src/events_collection.dart
+++ b/lib/src/events_collection.dart
@@ -37,6 +37,9 @@ import 'package:w_module/src/event.dart';
 ///       }
 ///     }
 class EventsCollection extends Disposable {
+  @override
+  String get disposableTypeName => 'EventsCollection';
+
   /// The key that every [Event] instance included as a part of this
   /// [EventsCollection] should be tied to.
   ///

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -923,8 +923,8 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       String reason}) {
     reason = reason ??
         'Only a module in the '
-        '${allowedStates.map(_readableStateName).join(", ")} states can '
-        'transition to ${_readableStateName(targetState)}';
+            '${allowedStates.map(_readableStateName).join(", ")} states can '
+            'transition to ${_readableStateName(targetState)}';
     return new Future.error(new StateError(
         'Transitioning from $_state to $targetState is not allowed. $reason'));
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,8 +22,8 @@ dependencies:
 
 dev_dependencies:
   build_runner: ">=0.6.0 <2.0.0"
-  build_test: ">=0.9.0 <1.0.0"
-  build_web_compilers: ">=0.2.0 <2.0.0"
+  build_test: ">=0.9.0 <2.0.0"
+  build_web_compilers: ">=0.2.0 <3.0.0"
   coverage: ">=0.10.0 <0.13.0"
   dart_dev: ^2.0.0
   dart_style: ^1.0.9

--- a/test/events_collection_test.dart
+++ b/test/events_collection_test.dart
@@ -19,6 +19,9 @@ import 'package:w_module/w_module.dart';
 final _key = new DispatchKey('test');
 
 class TestEvents extends EventsCollection {
+  @override
+  String get disposableTypeName => 'TestEvents';
+
   final Event<String> eventA = new Event<String>(_key);
   final Event<String> eventB = new Event<String>(_key);
 

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -32,6 +32,9 @@ const String shouldUnloadError = 'Mock shouldUnload false message';
 class MockStreamSubscription extends Mock implements StreamSubscription<Null> {}
 
 class UnnamedModule extends LifecycleModule {
+  @override
+  String get disposableTypeName => 'UnnamedModule';
+
   // This module does not override the name getter
   // so lifecycle methods should not create spans
 
@@ -43,6 +46,9 @@ class UnnamedModule extends LifecycleModule {
 }
 
 class TestLifecycleModule extends LifecycleModule {
+  @override
+  String get disposableTypeName => 'TestLifecycleModule';
+
   Iterable<StreamSubscription<LifecycleModule>> _eventListStreamSubscriptions;
 
   Duration onLoadDelay;


### PR DESCRIPTION
Some of the classes that extend or mixin `Disposable` missing `disposableTypeName` override.
     This PR will add missing overrides, where it's necessary