### PR TITLE
Fix w_module example in Dart 2, fix up action deprecations and missing types

### DIFF
--- a/example/panel/modules/data_load_async_module.dart
+++ b/example/panel/modules/data_load_async_module.dart
@@ -66,7 +66,7 @@ class DataLoadAsyncComponents implements ModuleComponents {
 }
 
 class DataLoadAsyncActions {
-  final Action loadData = new Action();
+  final Action<Null> loadData = new Action();
 }
 
 DispatchKey _dispatchKey = new DispatchKey('DataLoadAsync');

--- a/example/panel/modules/flux_module.dart
+++ b/example/panel/modules/flux_module.dart
@@ -49,7 +49,7 @@ class FluxComponents implements ModuleComponents {
 }
 
 class FluxActions {
-  final Action changeBackgroundColor = new Action();
+  final Action<Null> changeBackgroundColor = new Action();
 }
 
 class FluxStore extends Store {
@@ -57,7 +57,7 @@ class FluxStore extends Store {
   String _backgroundColor = 'gray';
 
   FluxStore(this._actions) {
-    triggerOnAction(_actions.changeBackgroundColor, _changeBackgroundColor);
+    triggerOnActionV2(_actions.changeBackgroundColor, _changeBackgroundColor);
   }
 
   String get backgroundColor => _backgroundColor;
@@ -85,7 +85,7 @@ class _MyFluxComponent extends FluxComponent<FluxActions, FluxStore> {
       'This module uses a flux pattern to change its background color.',
       react.button({
         'style': {'padding': '10px', 'margin': '10px'},
-        'onClick': actions.changeBackgroundColor
+        'onClick': (_) => actions.changeBackgroundColor()
       }, 'Random Background Color')
     ]);
   }

--- a/example/panel/modules/hierarchy_module.dart
+++ b/example/panel/modules/hierarchy_module.dart
@@ -94,8 +94,8 @@ class HierarchyStore extends Store {
   List<Module> _childModules = [];
 
   HierarchyStore(this._actions) {
-    triggerOnAction(_actions.addChildModule, _addChildModule);
-    triggerOnAction(_actions.removeChildModule, _removeChildModule);
+    triggerOnActionV2(_actions.addChildModule, _addChildModule);
+    triggerOnActionV2(_actions.removeChildModule, _removeChildModule);
   }
 
   List<Module> get childModules => _childModules;

--- a/example/panel/modules/reject_module.dart
+++ b/example/panel/modules/reject_module.dart
@@ -58,7 +58,7 @@ class RejectComponents implements ModuleComponents {
 }
 
 class RejectActions {
-  final Action toggleShouldUnload = new Action();
+  final Action<Null> toggleShouldUnload = new Action();
 }
 
 class RejectStore extends Store {
@@ -69,7 +69,7 @@ class RejectStore extends Store {
   RejectActions _actions;
 
   RejectStore(this._actions) {
-    triggerOnAction(_actions.toggleShouldUnload, _toggleShouldUnload);
+    triggerOnActionV2(_actions.toggleShouldUnload, _toggleShouldUnload);
   }
 
   bool get shouldUnload => _shouldUnload;
@@ -96,7 +96,7 @@ class _RejectComponent extends FluxComponent<RejectActions, RejectStore> {
           'type': 'checkbox',
           'label': 'shouldUnload',
           'checked': store.shouldUnload,
-          'onChange': actions.toggleShouldUnload
+          'onChange': (_) => actions.toggleShouldUnload()
         }),
         'shouldUnload'
       ])

--- a/example/random_color/random_color.dart
+++ b/example/random_color/random_color.dart
@@ -121,8 +121,8 @@ class RandomColorComponents implements ModuleComponents {
 }
 
 class RandomColorActions {
-  final Action changeBackgroundColor = new Action();
-  final Action setBackgroundColor = new Action<String>();
+  final Action<Null> changeBackgroundColor = new Action();
+  final Action<String> setBackgroundColor = new Action();
 }
 
 class RandomColorStore extends Store {
@@ -176,7 +176,7 @@ class _RandomColorComponent
       'This module uses a flux pattern to change its background color.',
       react.button({
         'style': {'padding': '10px', 'margin': '10px'},
-        'onClick': actions.changeBackgroundColor
+        'onClick': (_) => actions.changeBackgroundColor()
       }, 'Change Background Color'),
       react.button({
         'style': {'padding': '10px', 'margin': '10px'},


### PR DESCRIPTION
## Motivation
The `/panel/` example wasn't working in Dart 2 due to typing issues.

## Changes
- Make callbacks into arrow functions so the event isn't passed through unintentially
- Use `triggerOnActionV2` which uses generic to fix listener tearoffs not being the right type

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#manual-testing-criteria
