### PR TITLE
CPLAT-7616: Preparations for React 16 compatibility

### DIFF
--- a/example/panel/panel_app.dart
+++ b/example/panel/panel_app.dart
@@ -19,6 +19,7 @@ import 'dart:html';
 import 'dart:js' as js;
 
 import 'package:platform_detect/platform_detect.dart';
+import 'package:over_react/over_react.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart' as react_client;
 import 'package:w_module/w_module.dart' hide Event;
@@ -58,5 +59,6 @@ Future<Null> main() async {
   });
 
   // render the app into the browser
-  react_dom.render(panelModule.components.content(), container);
+  react_dom.render(
+      ErrorBoundary()(panelModule.components.content()), container);
 }

--- a/example/random_color/random_color.dart
+++ b/example/random_color/random_color.dart
@@ -19,6 +19,7 @@ import 'dart:html' as html;
 import 'dart:math';
 
 import 'package:react/react.dart' as react;
+import 'package:over_react/over_react.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart' as react_client;
 
@@ -32,7 +33,7 @@ Future<Null> main() async {
 
   // render the module's UI component
   react_client.setClientConfiguration();
-  react_dom.render(randomColorModule.components.content(),
+  react_dom.render(ErrorBoundary()(randomColorModule.components.content()),
       html.querySelector('#content-container'));
 
   // exercise the module's API via some simple button clicks

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,8 @@ dev_dependencies:
   dart_dev: ^2.0.0
   dart_style: ^1.0.9
   mockito: ">=2.2.2 <4.0.0"
-  react: ^4.4.2
+  over_react: ">=2.5.1 <4.0.0"
+  react: ">=4.7.0 <6.0.0"
   test: ">=0.12.30 <2.0.0"
   w_flux: ">=1.0.0 <3.0.0"
 


### PR DESCRIPTION
> __These changes / builds will first be reviewed by a member of the Client Platform team.__ 
> 
> Repo owners will be notified when it is ready for additional review, merge and release.

## Motivation
Wdesk is currently using ReactJS `15.6.1` _(released on June 14, 2017)_, and the Client Platform team 
has been working to upgrade our Dart wrappers to be compatible with the latest major version of ReactJS (`16.x`). 
Now that major releases of the `react` (`5.0.0`) and `over_react` (`3.0.0`) packages have laid the foundation
for ReactJS 16 compatibility, __its time to begin making the entire Workiva front-end
ecosystem compatible!__

__But Why?__
The ReactJS `16.0.0` release included an internal rewrite that set the stage for some new features, 
ranging from new and improved APIs for authoring UI, to a new "concurrent mode" that improves performance 
_and perceived performance_ of Web applications.

Keeping React up-to-date and supporting its latest features — particularly those being introduced in the `16.x` line — 
will help us be more efficient at writing, maintaining, and optimizing our UIs.

## Changes
1. Raise the upper bounds of the `react` / `over_react` dependencies to allow the new major release versions to be pulled in once all downstream dependencies are also compatible.
2. Prepare code for React 16 via minor codemod updates. 
  1. All changes/fixes will be handled by Client Platform before repo owners are requested for review(s).
  2. Certain changes cannot be made automatically, but the codemod will add comments in the code for these cases. 
    1. The Client Platform team will go through and manually verify these edge-cases, and update the comment in a way that will ensure the [React 16 core check](https://wiki.atl.workiva.net/display/CP/Rollout+Plan#RolloutPlan-CoreCheck) will not fail moving forward. 
    
      __Please do not modify / remove these comments!__

#### Release Notes
Make this library compatible with ReactJS 16. 

## Review
Please review: @greglittlefield-wf @aaronlademann-wf @kealjones-wk @joebingham-wk @sydneyjodon-wk

### QA Checklist
- [ ] Passing CI

__NOTE:__ Manual React 16 testing should be done using #158 - not this branch.
  
> [More information about the React 16 upgrade](https://wiki.atl.workiva.net/pages/viewpage.action?spaceKey=CP&title=React+16)
