### PR TITLE
CPLAT-7620: React 16 Testing

### DIFF
--- a/example/panel/panel_app.dart
+++ b/example/panel/panel_app.dart
@@ -19,6 +19,7 @@ import 'dart:html';
 import 'dart:js' as js;
 
 import 'package:platform_detect/platform_detect.dart';
+import 'package:over_react/over_react.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart' as react_client;
 import 'package:w_module/w_module.dart' hide Event;
@@ -58,5 +59,6 @@ Future<Null> main() async {
   });
 
   // render the app into the browser
-  react_dom.render(panelModule.components.content(), container);
+  react_dom.render(
+      ErrorBoundary()(panelModule.components.content()), container);
 }

--- a/example/random_color/random_color.dart
+++ b/example/random_color/random_color.dart
@@ -19,6 +19,7 @@ import 'dart:html' as html;
 import 'dart:math';
 
 import 'package:react/react.dart' as react;
+import 'package:over_react/over_react.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart' as react_client;
 
@@ -32,7 +33,7 @@ Future<Null> main() async {
 
   // render the module's UI component
   react_client.setClientConfiguration();
-  react_dom.render(randomColorModule.components.content(),
+  react_dom.render(ErrorBoundary()(randomColorModule.components.content()),
       html.querySelector('#content-container'));
 
   // exercise the module's API via some simple button clicks

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,3 +36,7 @@ dev_dependencies:
 transformers:
   - test/pub_serve:
       $include: test/**_test{.*,}dart
+
+dependency_overrides:
+  react: ^5.0.0-alpha
+  over_react: ^3.0.0-alpha

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,8 @@ dev_dependencies:
   dart_dev: ^2.0.0
   dart_style: ^1.0.9
   mockito: ">=2.2.2 <4.0.0"
-  react: ^4.4.2
+  over_react: ">=2.5.1 <4.0.0"
+  react: ">=4.7.0 <6.0.0"
   test: ">=0.12.30 <2.0.0"
   w_flux: ">=1.0.0 <3.0.0"
 


### PR DESCRIPTION
> __These changes / builds will first be reviewed by a member of the Client Platform team.__ 
> 
> Repo owners will be notified when it is ready for additional review and testing.

## Motivation
We need a branch that forces ReactJS 16 compatible versions of `react` and `over_react` so that 
CI checks and manual smoke testing can be performed with ReactJS 16 running "under the hood".  

## Changes
_All of the changes from #157, plus:_

1. Add necessary dependency overrides to ensure that ReactJS 16 compatible versions of `react` and `over_react` dependencies are being used.

## Review
Please review: @greglittlefield-wf @aaronlademann-wf @kealjones-wk @joebingham-wk @sydneyjodon-wk

### QA Checklist
- [ ] Passing CI
  - [ ] Verify that the `pubspec.lock` artifact(s) in the CI builds contain the following dependencies:
    - `react 5.0.0-alpha`
    - `over_react 3.0.0-alpha` 
- [ ] Manual smoke testing _(in Dart 2 only)_ anywhere that you would normally smoke test your library / experience.
  
> [More information about the React 16 upgrade](https://wiki.atl.workiva.net/pages/viewpage.action?spaceKey=CP&title=React+16)
