### PR TITLE
Add missing stack traces to Future.errors

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -499,7 +499,8 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
     if (isUnloaded || isUnloading) {
       var stateLabel = isUnloaded ? 'unloaded' : 'unloading';
       return Future.error(
-          StateError('Cannot load child module when module is $stateLabel'));
+          StateError('Cannot load child module when module is $stateLabel'),
+          StackTrace.current);
     }
 
     final completer = Completer<Null>();
@@ -912,8 +913,10 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
     _logger.warning('.$methodName() was called after Module "$name" had '
         // ignore: deprecated_member_use
         'already ${isDisposing ? 'started disposing' : 'disposed'}.');
-    return Future.error(StateError(
-        'Calling .$methodName() after disposal has started is not allowed.'));
+    return Future.error(
+        StateError(
+            'Calling .$methodName() after disposal has started is not allowed.'),
+        StackTrace.current);
   }
 
   /// Returns a new [Future] error with a constructed reason.
@@ -925,8 +928,10 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
         'Only a module in the '
             '${allowedStates.map(_readableStateName).join(", ")} states can '
             'transition to ${_readableStateName(targetState)}';
-    return Future.error(StateError(
-        'Transitioning from $_state to $targetState is not allowed. $reason'));
+    return Future.error(
+        StateError(
+            'Transitioning from $_state to $targetState is not allowed. $reason'),
+        StackTrace.current);
   }
 
   Future<Null> _buildNoopResponse(


### PR DESCRIPTION
## Motivation
Some `Future.error`s were missing stack traces, which resulted in no stack traces getting logged.

## Changes
Add stack traces manually

I attempted to use async functions to do this (see https://github.com/Workiva/w_module/pull/165), but it ended up introducing subtle timing changes, which seemed too risky.

#### Release Notes
- Fix missing stacktraces in most StateErrors thrown by LifecycleModule

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#manual-testing-criteria
