### PR TITLE
Lower log level of no-op

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -938,7 +938,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       {@required String methodName,
       @required LifecycleState currentState,
       @required isTransitioning}) {
-    _logger.warning(
+    _logger.config(
         '.$methodName() was called while Module "$name" is already '
         '${_readableStateName(currentState)}; this is a no-op. Check for any '
         'unnecessary calls to .$methodName().',


### PR DESCRIPTION
## Motivation
[this query](https://splunk.workiva.net/en-US/app/search/search?q=search%20index%3Dkinesis-harbour-prod%20source%3Dapp-int-collection-gateway%20%22PresenceModule%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-24h%40h&latest=now&sid=1631799547.277575_E1E254A8-D1AC-4B03-A4B7-AB2DD555FC19) shows that something is flooding prod with this warning:

> .suspend() was called while Module "PresenceModule" is already suspended; this is a no-op. Check for any unnecessary calls to .suspend().

## Changes
We don't need to log like crazy for a no-op action, even if it is something we want to "warn" consumers about.

#### Release Notes
Lower the log severity of no-op calls to suspend.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#manual-testing-criteria
