### PR TITLE
Material-UI Migration Preparations

### DIFF
--- a/example/panel/index.html
+++ b/example/panel/index.html
@@ -25,6 +25,7 @@ limitations under the License.
         <div id="panel-container"></div>
 
         <script src="packages/react/react_with_react_dom_prod.js"></script>
+        <script src="packages/react_material_ui/react-material-ui.umd.js"></script>
         <script defer src="panel_app.dart.js"></script>
         
     </body>

--- a/example/panel/panel_app.dart
+++ b/example/panel/panel_app.dart
@@ -21,6 +21,7 @@ import 'dart:js' as js;
 import 'package:platform_detect/platform_detect.dart';
 import 'package:over_react/over_react.dart';
 import 'package:react/react_dom.dart' as react_dom;
+import 'package:react_material_ui/styles/theme_provider.dart';
 import 'package:react/react_client.dart' as react_client;
 import 'package:w_module/w_module.dart' hide Event;
 import 'package:opentracing/opentracing.dart';
@@ -60,5 +61,7 @@ Future<Null> main() async {
 
   // render the app into the browser
   react_dom.render(
-      ErrorBoundary()(panelModule.components.content()), container);
+      ErrorBoundary()(
+          (ThemeProvider()..theme = wkTheme)(panelModule.components.content())),
+      container);
 }

--- a/example/random_color/index.html
+++ b/example/random_color/index.html
@@ -37,6 +37,7 @@ limitations under the License.
         </div>
 
         <script src="packages/react/react_with_react_dom_prod.js"></script>
+        <script src="packages/react_material_ui/react-material-ui.umd.js"></script>
         <script defer src="random_color.dart.js"></script>
         
     </body>

--- a/example/random_color/random_color.dart
+++ b/example/random_color/random_color.dart
@@ -21,6 +21,7 @@ import 'dart:math';
 import 'package:react/react.dart' as react;
 import 'package:over_react/over_react.dart';
 import 'package:react/react_dom.dart' as react_dom;
+import 'package:react_material_ui/styles/theme_provider.dart';
 import 'package:react/react_client.dart' as react_client;
 
 import 'package:w_flux/w_flux.dart';
@@ -33,7 +34,9 @@ Future<Null> main() async {
 
   // render the module's UI component
   react_client.setClientConfiguration();
-  react_dom.render(ErrorBoundary()(randomColorModule.components.content()),
+  react_dom.render(
+      ErrorBoundary()((ThemeProvider()
+        ..theme = wkTheme)(randomColorModule.components.content())),
       html.querySelector('#content-container'));
 
   // exercise the module's API via some simple button clicks

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,11 @@ dependencies:
   meta: ^1.2.2
   opentracing: ^1.0.1
   platform_detect: ^1.3.5
+  react_material_ui:
+    hosted:
+      name: react_material_ui
+      url: https://pub.workiva.org
+    version: ^1.1.1
   w_common: ^1.20.1
 
 dev_dependencies:


### PR DESCRIPTION
## Motivation
[MUI component migrations](https://wiki.atl.workiva.net/display/CP/Material+Design) will begin soon, and there are a few housekeeping items that are necessary for a smooth rollout across the Workiva ecosystem.

A member of Client Platform will reach out when this PR is ready for team review.

If you have any questions about this PR, reach out to us in the [#support-mui-migration](https://workiva.slack.com/app_redirect?channel=support-mui-migration) Slack channel!

## Changes
This PR includes automated changes to ensure that the consumption of upstream dependencies that have migrated at least one Web Skin Dart component to MUI doesn't result in unexpected failures in this package or unexpected styling regressions in any of the standalone apps within this repo.

This is accomplished by:

1. Adding the JS MUI `<script>` tag to all HTML files used in this repo where React components are being rendered on the page
1. Adding `react_material_ui` as a dependency so that the `<script>` tags added do not cause 404 errors
1. Adding `react_material_ui` to the `dependency_validator` ignore list(s)
1. Wrapping top-level React trees (e.g. `react_dom.render` calls) in a `ThemeProvider` that sets the theme to our Workiva theme. This guards against components consumed from upstream dependencies being styled inconsistently.

The initial commit is automatically applied by a codemod and follow up commits may be made to:
- Fix tests

### Release Notes
Prepare for MUI component migrations

## QA Instructions
- [ ] CI Passes
- [ ] The app does not throw runtime exceptions when navigating to places where the top-level `react_dom.render` calls are relevant
  _(only necessary if functional tests run in CI does not navigate to all the views where the `react_dom.render` calls are used.)_

[_Created by Sourcegraph batch change `aaronlademann-wf/mui_migration_rmui_prep`._](https://sourcegraph.wk-dev.wdesk.org/users/aaronlademann-wf/batch-changes/mui_migration_rmui_prep)