### PR TITLE
Test Dart 2.18

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -18,7 +18,7 @@ jobs:
         sdk: [ 2.13.4, stable, beta, dev ]
     steps:
       - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v0.2
+      - uses: dart-lang/setup-dart@v1.3
         with:
           sdk: ${{ matrix.sdk }}
 
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v0.2
+      - uses: dart-lang/setup-dart@v1.3
         with:
           sdk: 2.13.4
 

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.13.4, stable, beta, dev ]
+        sdk: [ 2.13.4, 2.18.7 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/dart2_base_image:1
+FROM drydock-prod.workiva.net/workiva/dart2_base_image:0.0.0-dart2.18.7
 WORKDIR /build/
 ADD pubspec.yaml /build
 RUN dart pub get

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/dart2_base_image:0.0.0-dart2.18.7
+FROM drydock-prod.workiva.net/workiva/dart2_base_image:1
 WORKDIR /build/
 ADD pubspec.yaml /build
 RUN dart pub get

--- a/tool/dart_dev/config.dart
+++ b/tool/dart_dev/config.dart
@@ -16,5 +16,7 @@ import 'package:dart_dev/dart_dev.dart';
 
 final config = {
   ...coreConfig,
+  'analyze': AnalyzeTool()..useDartAnalyze = true,
+  'format': FormatTool()..formatter = Formatter.dartFormat,
   'serve': WebdevServeTool()..webdevArgs = ['example:8080']
 };


### PR DESCRIPTION
Summary
---
This batch overrides the docker images used to equivalent Dart 2.18 versions.
The goal is to run as many CI runs across the dart ecosystem as possible on 
Dart 2.18 to find and fix errors before releasing a production 2.18 image.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/test_dart_218`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/test_dart_218)