### PR TITLE
Upgrade to platform_detect 2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,3 +27,6 @@ dev_dependencies:
   react: ^6.1.6
   test: ^1.16.8
   w_flux: ^2.10.21
+
+dependency_overrides:
+  platform_detect: ^2.0.0


### PR DESCRIPTION
Summary
---

This is a test to verify the safety of allowing platform_detect v2.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/platform_detect_2`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/platform_detect_2)