### PR TITLE
Upgrade to platform_detect 2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
   matcher: ^0.12.10
   mockito: ^5.0.0
   over_react: ^4.4.0
-  platform_detect: ^1.4.2
+  platform_detect: '>=1.4.2 <3.0.0'
   react: ^6.1.6
   test: ^1.16.8
   w_flux: ^2.10.21


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This will raise the max allowed version of platform_detect to allow v2.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/platform_detect_2_raise_max`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/platform_detect_2_raise_max)