### PR TITLE
Test compatibility with w_module 3 and w_transport 5

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -25,5 +25,5 @@ dependency_validator:
     - mockito
 
 dependency_overrides:
-  w_module:
-    path: ../
+  w_module: ^3.0.0
+  w_transport: ^5.0.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,13 +19,13 @@ dev_dependencies:
   w_common: '>=2.0.0 <4.0.0'
   w_flux: ^2.10.21
   w_module:
+    path: ../
 
 dependency_validator:
   ignore:
     - mockito
 
 dependency_overrides:
-  w_module: ^3.0.0
   w_transport: 
     git:
       url: git@github.com:Workiva/w_transport.git

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -26,4 +26,7 @@ dependency_validator:
 
 dependency_overrides:
   w_module: ^3.0.0
-  w_transport: ^5.0.0
+  w_transport: 
+    git:
+      url: git@github.com:Workiva/w_transport.git
+      ref: tweak_collection_dep

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,13 +19,14 @@ dev_dependencies:
   w_common: '>=2.0.0 <4.0.0'
   w_flux: ^2.10.21
   w_module:
-    path: ../
 
 dependency_validator:
   ignore:
     - mockito
 
 dependency_overrides:
+  w_module:
+    path: ../
   w_transport: 
     git:
       url: git@github.com:Workiva/w_transport.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,3 +28,7 @@ dependency_validator:
     - "example/**"
   ignore:
     - mockito
+
+dependency_overrides:
+  w_module: ^3.0.0
+  w_transport: ^5.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,4 +31,7 @@ dependency_validator:
 
 dependency_overrides:
   w_module: ^3.0.0
-  w_transport: ^5.0.0
+  w_transport: 
+    git:
+      url: git@github.com:Workiva/w_transport.git
+      ref: tweak_collection_dep

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,6 @@ dependency_validator:
     - mockito
 
 dependency_overrides:
-  w_module: ^3.0.0
   w_transport: 
     git:
       url: git@github.com:Workiva/w_transport.git


### PR DESCRIPTION
DO NOT MERGE. This PR adds a dependency override to test whether this repo is compatible with w_module 3 and w_transport 5
For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/test_wmodule_wtransport`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/test_wmodule_wtransport)