### PR TITLE
Avoid meta 1.10.0 problem by unblocking analyzer 5

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,7 +11,7 @@ dev_dependencies:
   build_runner: ^2.1.2
   build_web_compilers: ^3.0.0
   dependency_validator: ^3.2.2
-  meta: '>=1.6.0  <1.10.0'
+  meta: ^1.6.0
   opentracing: ^1.0.1
   over_react: ^4.4.0
   platform_detect: '>=1.4.2 <3.0.0'
@@ -19,11 +19,6 @@ dev_dependencies:
   w_common: ^3.0.0
   w_flux: ^2.10.21
   w_module:
-
-dependency_validator:
-  ignore:
-    - meta
-    - mockito
 
 dependency_overrides:
   w_module:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,7 +11,7 @@ dev_dependencies:
   build_runner: ^2.1.2
   build_web_compilers: ^3.0.0
   dependency_validator: ^3.2.2
-  meta: ^1.6.0
+  meta: '>=1.6.0  <1.10.0'
   opentracing: ^1.0.1
   over_react: ^4.4.0
   platform_detect: '>=1.4.2 <3.0.0'
@@ -22,6 +22,7 @@ dev_dependencies:
 
 dependency_validator:
   ignore:
+    - meta
     - mockito
 
 dependency_overrides:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   logging: ^1.0.0
-  meta: '>=1.6.0  <1.10.0'
+  meta: ^1.6.0
   opentracing: ^1.0.1
   w_common: ^3.0.0
 
@@ -20,12 +20,9 @@ dev_dependencies:
   dart_style: ^2.1.1
   dependency_validator: ^3.2.2
   matcher: ^0.12.10
-  mockito: '>=5.0.0 <5.3.0' # pin to workaround https://github.com/dart-lang/mockito/issues/552
+  mockito: ^5.3.1
   test: ^1.16.8
 
 dependency_validator:
   exclude:
     - "example/**"
-  ignore:
-    - meta
-    - mockito

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   logging: ^1.0.0
-  meta: ^1.6.0
+  meta: '>=1.6.0  <1.10.0'
   opentracing: ^1.0.1
   w_common: ^3.0.0
 
@@ -27,4 +27,5 @@ dependency_validator:
   exclude:
     - "example/**"
   ignore:
+    - meta
     - mockito


### PR DESCRIPTION
Summary
---
This is a batch change to apply a dependency range pin to the meta package
in order to avoid a "bad release". That version causes nearly all of our builds to
fail (anything on analyzer < 5).
So restricting the version range to <1.10.0 works around the issue until we
can upgrade to analyzer 5.

For more info, visit `#lang-dart` in Slack.

[_Created by Sourcegraph batch change `Workiva/avoid_meta_1_10_0`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/avoid_meta_1_10_0)