### PR TITLE
Add workiva_dependency_constrainer

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,8 +18,17 @@ dev_dependencies:
   react: ^6.1.6
   w_common: ^3.0.0
   w_flux: ^2.10.21
-  w_module:
+  w_module
+  workiva_dependency_constrainer:
+    hosted:
+      name: workiva_dependency_constrainer
+      url: https://pub.workiva.org
+    version: ^1.0.0:
 
 dependency_overrides:
   w_module:
     path: ../
+
+dependency_validator:
+  ignore:
+    - workiva_dependency_constrainer

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,14 @@ dev_dependencies:
   matcher: ^0.12.10
   mockito: ^5.3.1
   test: ^1.16.8
+  workiva_dependency_constrainer:
+    hosted:
+      name: workiva_dependency_constrainer
+      url: https://pub.workiva.org
+    version: ^1.0.0
 
 dependency_validator:
+  ignore:
+    - workiva_dependency_constrainer
   exclude:
     - "example/**"


### PR DESCRIPTION
# Summary
In order to make the upgrade to analyzer 5 more predictable,
Frontend Frameworks is adding a dev dependency on a new package
`workiva_dependency_constrainer` which constrains analyzer to ^2,
mockito to `'>=5.0.0 <5.3.0'` and meta to `'>=1.6.0 <1.10.0'`

Once analyzer 5 ready packages for over_react, dart_storybook,
puppeteer_platform, and json_serializable_3_5_2 are released
and tested, then a newer version of the constrainer will be
released to unpin analyzer and mockito. This will prevent
repos from upgrading in an unpredictable order or time and
keeps things how they are until we're all ready to upgrade at
the same time.

As part of this batch, the pin on mockito and meta in this repo
will be removed, since they are now handled by the constrainer.
The extra dependency validator ignores on meta and mockito are
also removed.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/add_wdc`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/add_wdc)