### PR TITLE
Rollout Analyzer 5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,8 +20,8 @@ dev_dependencies:
   dart_style: ^2.1.1
   dependency_validator: ^3.2.2
   matcher: ^0.12.10
-  mockito: ^5.3.1
-  test: ^1.16.8
+  mockito: ^5.3.2
+  test: ^1.21.1
 
 dependency_validator:
   exclude:


### PR DESCRIPTION
# Rollout Analyzer 5

This batch will raise the minimum of workiva_dependency_constrainer
to one that requires analyzer 5, thus ensuring that a repo resolves
to analyzer 5. It also raises the minimums of other packages that
are needed, like built_value.

## Things that may need fixing manually

1. Probably the most common thing is that built_value generated code
will need to be regenerated. There should be no breaking changes in
this new generated code. Some repos have a make target called `gen`,
`gen-built` or similar, or just run a full `dart run build_runner build`

2. The temporary fix for Dart coverage needs to be removed. The fix
is to simply remove lines like these below from Github Actions. This PR
will have raised the minimum of the test package to 1.21.1 which is
the first version needed that removes the need to backpatched test
versions.
```
  - uses: Workiva/gha-dart/temp-coverage-setup@v0.2.28
    with:
      test-package-version: 1.20.1
```

3. As part of moving to analyzer 5, the sort_pub_dependencies lint 
seems to act as a warning now, causing analyze to fail CI.
To fix: either sort the dependencies in alphabetical order or
alter the analysis_options.yaml to lower the severity to a hint



For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/analyzer_5`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/analyzer_5)