### PR TITLE
Avoid accessing private members of child modules

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.18.7 ]
+        sdk: [ 2.18.7 , 2.19.6]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.3

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -570,7 +570,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
   }
 
   /// Provide a way for a module to update its children's parentContext that is compatible with mocking in 2.19.
-  /// 
+  ///
   /// This is only intended for use within this file and is marked protected.
   @protected
   set parentContext(SpanContext? context) => _parentContext = context;

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -528,7 +528,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       try {
         manageDisposable(childModule);
         _childModules.add(childModule);
-        childModule._parentContext = _loadContext;
+        _setParentContextOnChild(childModule, _loadContext);
 
         await childModule.load();
         try {
@@ -554,7 +554,7 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
         _didLoadChildModuleController.addError(error, stackTrace);
         completer.completeError(error, stackTrace);
       } finally {
-        childModule._parentContext = null;
+        _setParentContextOnChild(childModule, null);
       }
     }).catchError((Object error, StackTrace stackTrace) {
       _logger.severe(
@@ -567,6 +567,16 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
     });
 
     return completer.future;
+  }
+
+  /// This method is a workaround for the dangers of mock modules. A mock cannot implement a private member, so this will fail.
+  void _setParentContextOnChild(
+    LifecycleModule? childModule,
+    SpanContext? context,
+  ) {
+    try {
+      childModule?._parentContext = context;
+    } catch (e) {}
   }
 
   /// Public method to suspend the module.
@@ -1034,9 +1044,9 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       List<Future<Null>> childResumeFutures = <Future<Null>>[];
       for (var child in _childModules.toList()) {
         childResumeFutures.add(Future.sync(() {
-          child._parentContext = _activeSpan?.context;
+          _setParentContextOnChild(child, _activeSpan?.context);
           return child.resume().whenComplete(() {
-            child._parentContext = null;
+            _setParentContextOnChild(child, null);
           });
         }));
       }
@@ -1071,9 +1081,9 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       List<Future<Null>> childSuspendFutures = <Future<Null>>[];
       for (var child in _childModules.toList()) {
         childSuspendFutures.add(Future.sync(() async {
-          child._parentContext = _activeSpan?.context;
+          _setParentContextOnChild(child, _activeSpan?.context);
           return child.suspend().whenComplete(() {
-            child._parentContext = null;
+            _setParentContextOnChild(child, null);
           });
         }));
       }
@@ -1119,9 +1129,9 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
 
       _willUnloadController.add(this);
       await Future.wait(_childModules.toList().map((child) {
-        child._parentContext = _activeSpan?.context;
+        _setParentContextOnChild(child, _activeSpan?.context);
         return child.unload().whenComplete(() {
-          child._parentContext = null;
+          _setParentContextOnChild(child, null);
         });
       }));
       try {


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
In dart 2.19 mocks can no longer handle calls into these private members.

## Changes
  <!-- What this PR changes to fix the problem. -->
Wrap calls into _parentContext in a try...catch to handle this gracefully.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Architecture team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-frontend-architecture Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Architecture member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#manual-testing-criteria
