### PR TITLE
react 7 and w_flux 3 step 2

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -15,9 +15,9 @@ dev_dependencies:
   opentracing: ^1.0.1
   over_react: ^4.4.0
   platform_detect: '>=1.4.2 <3.0.0'
-  react: '>=6.1.6 <8.0.0'
+  react: ^7.0.0
   w_common: ^3.0.0
-  w_flux: '>=2.10.21 <4.0.0'
+  w_flux: ^3.0.0
   w_module:
 
 dependency_overrides:


### PR DESCRIPTION
This PR raises the minimum versions for react and w_flux ensuring that these versions are used everywhere.
Feel free to review, approve and merge if CI passes. Otherwise someone on FEDX will come around and get it merged.
For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/react_flux_majors_2`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/react_flux_majors_2)