### PR TITLE
Ensure all child modules get unloaded

### DIFF
--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -1125,6 +1125,10 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
 
       _willUnloadController.add(this);
 
+      // We're looping here because it's possible for additional child modules to be added to this list while we are
+      // unloading the current items. While loadChildModule is guarded from adding new modules after unload starts, 
+      // it contains asynchronous elements that allow a module to be added to this list during the unload. 
+      // Note that items get removed from this list by an event handler listening to their didDispose stream.
       while (_childModules.isNotEmpty) {
         await Future.wait(_childModules.toList().map((child) {
           child.parentContext = _activeSpan?.context;

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -1126,8 +1126,8 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       _willUnloadController.add(this);
 
       // We're looping here because it's possible for additional child modules to be added to this list while we are
-      // unloading the current items. While loadChildModule is guarded from adding new modules after unload starts, 
-      // it contains asynchronous elements that allow a module to be added to this list during the unload. 
+      // unloading the current items. While loadChildModule is guarded from adding new modules after unload starts,
+      // it contains asynchronous elements that allow a module to be added to this list during the unload.
       // Note that items get removed from this list by an event handler listening to their didDispose stream.
       while (_childModules.isNotEmpty) {
         await Future.wait(_childModules.toList().map((child) {

--- a/lib/src/lifecycle_module.dart
+++ b/lib/src/lifecycle_module.dart
@@ -1124,12 +1124,16 @@ abstract class LifecycleModule extends SimpleModule with Disposable {
       _activeSpan = _startTransitionSpan('unload');
 
       _willUnloadController.add(this);
-      await Future.wait(_childModules.toList().map((child) {
-        child.parentContext = _activeSpan?.context;
-        return child.unload().whenComplete(() {
-          child.parentContext = null;
-        });
-      }));
+
+      while (_childModules.isNotEmpty) {
+        await Future.wait(_childModules.toList().map((child) {
+          child.parentContext = _activeSpan?.context;
+          return child.unload().whenComplete(() {
+            child.parentContext = null;
+          });
+        }));
+      }
+
       try {
         await onUnload();
       } catch (error, stackTrace) {


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
I discovered that tests in DPC were failing when I adjusted the timing of module load. 

The cause:
Child module was loaded.
Parent module was unloaded. Clearing the _childModules list.
onWillLoadChildModule completes allowing the child module to enter the _childModules list.
Parent module disposes triggering child module dispose. 
Child module dispose triggers child module unload, which explodes due to disposed stream controllers.


## Changes
  <!-- What this PR changes to fix the problem. -->

Continue clearing out the child module list until it is empty. 

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Architecture team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-frontend-architecture Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Architecture member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#manual-testing-criteria
