### PR TITLE
Dispose modules during onLoad if parent is unloaded/unloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.0.6](https://github.com/Workiva/w_module/compare/3.0.5...3.0.6)
+
+_March 4, 2024_
+
+- **Bug Fix:** A child module which loads during the unload of the parent
+  may cause BadState exceptions.
+
 ## [3.0.0](https://github.com/Workiva/w_module/compare/2.0.5...3.0.0)
 
 _August 18, 2023_

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -1756,6 +1756,29 @@ void runTests(bool runSpanTests) {
             childModule.eventList, equals(['willLoad', 'onLoad', 'didLoad']));
       });
 
+      test('followed by parent unload causes child to dispose and never load',
+          () async {
+        parentModule.eventList?.clear();
+        final load = parentModule.loadChildModule(childModule);
+
+        await parentModule.unload();
+        await load;
+
+        expect(
+          parentModule.eventList,
+          equals([
+            'onWillLoadChildModule',
+            'onShouldUnload',
+            'willUnload',
+            'onUnload',
+            'didUnload',
+            'onDispose'
+          ]),
+        );
+
+        expect(childModule.eventList, equals(['onDispose']));
+      });
+
       test('should emit lifecycle log events', () async {
         expect(
             Logger.root.onRecord,


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
When a child module is loaded, it is possible for the unload of the parent to complete before the onWillLoadChildModule handler executes. 

This is a second attempt at a safe implementation of https://github.com/Workiva/w_module/pull/239.

## Changes
  <!-- What this PR changes to fix the problem. -->
Check unloading/unloaded and just dispose in that handler instead.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
Fix bug where child module loads during the unload of the parent causing Bad State exceptions.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Architecture team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-frontend-architecture Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Architecture member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#manual-testing-criteria
