### PR TITLE
Replace mockito with mocktail

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,3 @@
 targets:
   $default:
     builders:
-      # mockito's builder is expensive and is not needed until this package is
-      # migrated to null-safety. At that point, it should be scoped only to
-      # relevant files.
-      mockito:mockBuilder:
-        enabled: false

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dev_dependencies:
   dart_style: ^2.1.1
   dependency_validator: ^3.2.2
   matcher: ^0.12.10
-  mockito: ^5.3.1
+  mocktail: ^1.0.3
   test: ^1.16.8
 
 dependency_validator:

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -17,7 +17,7 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart' show protected;
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:opentracing/noop_tracer.dart';
 import 'package:opentracing/opentracing.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
In order to help with build times and ease null safety migration, we've opted to replace mockito with mocktail. This batch runs the codemod to swap things out, but may require manual intervention.
FEDX will come around and fix things up unless you beat us to it. Once CI is green and the PR is not in draft, you can review and merge it.
For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/mocktail`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/mocktail)