### PR TITLE
Raise the meta dependency min to v1.16.0

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,7 +11,7 @@ dev_dependencies:
   build_runner: ^2.1.2
   build_web_compilers: '>=3.0.0 <5.0.0'
   dependency_validator: ^3.2.2
-  meta: ^1.6.0
+  meta: ^1.16.0
   opentracing: ^1.0.1
   over_react: ^5.0.0
   platform_detect: '>=1.4.2 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   logging: ^1.0.0
-  meta: ^1.6.0
+  meta: ^1.16.0
   opentracing: ^1.0.1
   w_common: ^3.0.0
 


### PR DESCRIPTION
This PR raises the min version of meta to 1.16.0. Passing CI
should be sufficient for QA, so feel free to review and merge this once CI completes.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/meta_raise_min_v1_16_0_really`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/meta_raise_min_v1_16_0_really)