### PR TITLE
FEA-7213: Log a warning and skip if child module takes too long to unload

### DIFF
--- a/lib/w_module.dart
+++ b/lib/w_module.dart
@@ -23,7 +23,8 @@ library w_module;
 
 export 'package:w_module/src/event.dart';
 export 'package:w_module/src/events_collection.dart';
-export 'package:w_module/src/lifecycle_module.dart' hide LifecycleState;
+export 'package:w_module/src/lifecycle_module.dart'
+    hide LifecycleState, maxChildUnloadDuration;
 export 'package:w_module/src/module.dart';
 export 'package:w_module/src/simple_module.dart';
 export 'package:w_module/src/timing_specifiers.dart';

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -262,8 +262,10 @@ class TestLifecycleModule extends LifecycleModule {
 }
 
 class ModuleThatNeverUnloads extends LifecycleModule {
+  Completer<Null> _onUnload = Completer<Null>();
+
   @override
-  Future<Null> onUnload() => Completer<Null>().future;
+  Future<Null> onUnload() => _onUnload.future;
 }
 
 void expectInLifecycleState(LifecycleModule module, LifecycleState state) {
@@ -2432,6 +2434,7 @@ void runTests(bool runSpanTests) {
               ));
 
           var badChildModule = ModuleThatNeverUnloads();
+          addTearDown(badChildModule._onUnload.complete);
           await parentModule.loadChildModule(childModule);
           await parentModule.loadChildModule(badChildModule);
           await parentModule

--- a/test/lifecycle_module_test.dart
+++ b/test/lifecycle_module_test.dart
@@ -261,6 +261,11 @@ class TestLifecycleModule extends LifecycleModule {
   }
 }
 
+class ModuleThatNeverUnloads extends LifecycleModule {
+  @override
+  Future<Null> onUnload() => Completer<Null>().future;
+}
+
 void expectInLifecycleState(LifecycleModule module, LifecycleState state) {
   var isInState = false;
   switch (state) {
@@ -2408,6 +2413,30 @@ void runTests(bool runSpanTests) {
                 'onDispose',
               ]));
           expect(childModule.eventList, isEmpty);
+        });
+
+        test('and warns if it takes too long', () async {
+          var originalDuration = maxChildUnloadDuration;
+          addTearDown(() {
+            maxChildUnloadDuration = originalDuration;
+          });
+          maxChildUnloadDuration = Duration(milliseconds: 10);
+
+          expect(
+              Logger.root.onRecord,
+              emitsThrough(
+                logRecord(
+                  level: Level.FINEST,
+                  message: contains('didUnloadChildModule'),
+                ),
+              ));
+
+          var badChildModule = ModuleThatNeverUnloads();
+          await parentModule.loadChildModule(childModule);
+          await parentModule.loadChildModule(badChildModule);
+          await parentModule
+              .unload()
+              .timeout(Duration(milliseconds: 20), onTimeout: () {});
         });
       });
 


### PR DESCRIPTION
# [FEA-7213](https://jira.atl.workiva.net/browse/FEA-7213)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEA-7213)

## Motivation
We recently had a scenario where a change to a module prevented it from completing its unload/dispose lifecycle hook. As a result, any parent module using that child module would hang while unloading/disposing. Due to us not handling that well (which has since been fixed), this also resulted in our experience manager not being able to reopen such an experience due to it never fully closing.

## Changes
- Adds a timeout to the unload step of each child module of 30 seconds. This should be more than enough time to perform an unload; in reality, it should never be close to this timeout.
- When the timeout is hit, we log a warning so that we can identify which module is hanging and so we can setup alerts/queries to know when this is happening.
- When the timeout is hit, we also stop waiting for that child module. This should unblock the unloading of the parent module, although it doesn't gaurantee that something with that child module (and thus by extension, the parent module) isn't broken, and it may result in a memory leak. This is no worse, and should be marginally better, than if the child module just never unloaded.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Architecture team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-frontend-architecture Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Architecture member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_module/blob/master/CONTRIBUTING.md#manual-testing-criteria
