### PR TITLE
RM-302028 Release w_module 3.0.9

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_module
-version: 3.0.8
+version: 3.0.9
 description: Base module classes with a well defined lifecycle for modular Dart applications.
 homepage: https://github.com/Workiva/w_module
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FEA-7213: Log a warning and skip if child module takes too long to unload](https://github.com/Workiva/w_module/pull/262)


Requested by: @alanknight-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_module/compare/3.0.8...Workiva:release_w_module_3.0.9
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_module/compare/3.0.8...3.0.9

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5434157055082496/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5434157055082496/?repo_name=Workiva%2Fw_module&pull_number=263)