### PR TITLE
FEDX-2835: Fixed issues from release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,8 @@ on:
 
 jobs:
   checks:
-    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.3
+    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.7
   build:
-    uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.3
+    uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.7
   test:
-    uses: Workiva/gha-dart-oss/.github/workflows/test-unit.yaml@v0.1.3
+    uses: Workiva/gha-dart-oss/.github/workflows/test-unit.yaml@v0.1.7

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   publish:
-    uses: Workiva/gha-dart-oss/.github/workflows/publish.yaml@v0.1.3
+    uses: Workiva/gha-dart-oss/.github/workflows/publish.yaml@v0.1.7

--- a/dart_dependency_validator.yaml
+++ b/dart_dependency_validator.yaml
@@ -1,0 +1,2 @@
+exclude:
+  - "example/**"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,12 +18,7 @@ dev_dependencies:
   build_web_compilers: '>=3.0.0 <5.0.0'
   dart_dev: ^4.0.0
   dart_style: ^2.1.1
-  dependency_validator: ^3.2.2
   matcher: ^0.12.10
   mocktail: ^1.0.3
   test: ^1.16.8
   workiva_analysis_options: ^1.4.1
-
-dependency_validator:
-  exclude:
-    - "example/**"


### PR DESCRIPTION
# [FEDX-2835](https://jira.atl.workiva.net/browse/FEDX-2835)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-2835)

## Motivation

Release CI is failing due to missing CHANGELOG entries. There is a check in gha-dart-oss which prevents this, but its in a more recent version

This PR updates w_module to use the latest gha-dart-oss to implement the check to catch the release errors before the release PR is merged

## Merge Checklist
- [ ] CI passes
