### PR TITLE
TEST: Running tests on React 18

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -25,13 +25,9 @@ dependency_overrides:
     path: ../
   react:
     git:
-      url: https://github.com/Workiva/react-dart.git
+      url: git@github.com:Workiva/react-dart.git
       ref: react-18-2-0-testing
   react_testing_library:
     git:
-      url: https://github.com/Workiva/react_testing_library.git
+      url: git@github.com:Workiva/react_testing_library.git
       ref: r18
-  dart_dev_workiva:
-    git:
-      url: https://github.com/Workiva/dart_dev_workiva.git
-      ref: override-react-js-files-for-r18

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -25,5 +25,9 @@ dependency_overrides:
     path: ../
   react:
     git:
-      url: git@github.com:Workiva/react-dart.git
+      url: https://github.com/Workiva/react-dart.git
       ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -27,7 +27,3 @@ dependency_overrides:
     git:
       url: git@github.com:Workiva/react-dart.git
       ref: react-18-2-0-testing
-  react_testing_library:
-    git:
-      url: git@github.com:Workiva/react_testing_library.git
-      ref: r18

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -23,3 +23,15 @@ dev_dependencies:
 dependency_overrides:
   w_module:
     path: ../
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,13 +25,9 @@ dev_dependencies:
 dependency_overrides:
   react:
     git:
-      url: https://github.com/Workiva/react-dart.git
+      url: git@github.com:Workiva/react-dart.git
       ref: react-18-2-0-testing
   react_testing_library:
     git:
-      url: https://github.com/Workiva/react_testing_library.git
+      url: git@github.com:Workiva/react_testing_library.git
       ref: r18
-  dart_dev_workiva:
-    git:
-      url: https://github.com/Workiva/dart_dev_workiva.git
-      ref: override-react-js-files-for-r18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,5 +25,9 @@ dev_dependencies:
 dependency_overrides:
   react:
     git:
-      url: git@github.com:Workiva/react-dart.git
+      url: https://github.com/Workiva/react-dart.git
       ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,3 +22,16 @@ dev_dependencies:
   mocktail: ^1.0.3
   test: ^1.16.8
   workiva_analysis_options: ^1.4.1
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,3 @@ dependency_overrides:
     git:
       url: git@github.com:Workiva/react-dart.git
       ref: react-18-2-0-testing
-  react_testing_library:
-    git:
-      url: git@github.com:Workiva/react_testing_library.git
-      ref: r18


### PR DESCRIPTION
DO NOT MERGE. No action needed. This PR adds dependency overrides to https://github.com/Workiva/react-dart/pull/416
in order to test all consumers before rolling out React 18 in all repos.
For more info, see [our Wiki page with the rollout plan](https://wiki.atl.workiva.net/spaces/FEF/pages/405122049/React+18+Upgrade) and reach out to `#support-ui-platform` on Slack with any questions.

[_Created by Sourcegraph batch change `Workiva/react_18_test`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/react_18_test)