### PR TITLE
Rollout React 18 to tests and example apps

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,9 +13,9 @@ dev_dependencies:
   dependency_validator: ^3.2.2
   meta: ^1.16.0
   opentracing: ^1.0.1
-  over_react: ^5.0.0
+  over_react: ^5.4.5
   platform_detect: '>=1.4.2 <3.0.0'
-  react: ^7.0.0
+  react: ^7.3.0
   w_common: ^3.0.0
   w_flux: ^3.0.0
   w_module:

--- a/example/web/panel/index.html
+++ b/example/web/panel/index.html
@@ -24,7 +24,7 @@ limitations under the License.
     <body>
         <div id="panel-container"></div>
 
-        <script src="packages/react/react_with_react_dom_prod.js"></script>
+        <script src="packages/react/js/react.min.js"></script>
         <script defer src="panel_app.dart.js"></script>
         
     </body>

--- a/example/web/random_color/index.html
+++ b/example/web/random_color/index.html
@@ -36,7 +36,7 @@ limitations under the License.
             <div id="content-container" style="border: 5px dashed red"></div>
         </div>
 
-        <script src="packages/react/react_with_react_dom_prod.js"></script>
+        <script src="packages/react/js/react.min.js"></script>
         <script defer src="random_color.dart.js"></script>
         
     </body>


### PR DESCRIPTION
This PR updates all references to React JS files from the React 17 to [React 18 versions](https://github.com/Workiva/react-dart?tab=readme-ov-file#react-18) which will cause most tests and example apps to run on React 18.